### PR TITLE
feat: v0.11.0 - 静的メソッド呼び出し・typeof・instanceof

### DIFF
--- a/src/Irooon.Core/Ast/Expressions/InstanceOfExpr.cs
+++ b/src/Irooon.Core/Ast/Expressions/InstanceOfExpr.cs
@@ -1,0 +1,24 @@
+namespace Irooon.Core.Ast.Expressions;
+
+/// <summary>
+/// instanceof 演算子を表します（例: obj instanceof ClassName）。
+/// </summary>
+public class InstanceOfExpr : Expression
+{
+    /// <summary>
+    /// チェック対象のオブジェクト式
+    /// </summary>
+    public Expression Object { get; }
+
+    /// <summary>
+    /// クラス名
+    /// </summary>
+    public string ClassName { get; }
+
+    public InstanceOfExpr(Expression obj, string className, int line, int column)
+        : base(line, column)
+    {
+        Object = obj;
+        ClassName = className;
+    }
+}

--- a/src/Irooon.Core/Lexer/Lexer.cs
+++ b/src/Irooon.Core/Lexer/Lexer.cs
@@ -47,6 +47,7 @@ public class Lexer
         { "export", TokenType.Export },
         { "from", TokenType.From },
         { "match", TokenType.Match },
+        { "instanceof", TokenType.InstanceOf },
         { "true", TokenType.True },
         { "false", TokenType.False },
         { "null", TokenType.Null },

--- a/src/Irooon.Core/Lexer/TokenType.cs
+++ b/src/Irooon.Core/Lexer/TokenType.cs
@@ -42,6 +42,7 @@ public enum TokenType
     Export,
     From,
     Match,
+    InstanceOf,
 
     // 演算子
     Plus,           // +

--- a/src/Irooon.Core/Parser/Parser.cs
+++ b/src/Irooon.Core/Parser/Parser.cs
@@ -274,6 +274,14 @@ public class Parser
             expr = new BinaryExpr(expr, op.Type, right, op.Line, op.Column);
         }
 
+        // instanceof 演算子
+        if (Match(TokenType.InstanceOf))
+        {
+            var op = Previous();
+            var className = Consume(TokenType.Identifier, "Expect class name after 'instanceof'.");
+            expr = new InstanceOfExpr(expr, className.Lexeme, op.Line, op.Column);
+        }
+
         return expr;
     }
 

--- a/src/Irooon.Core/Resolver/Resolver.cs
+++ b/src/Irooon.Core/Resolver/Resolver.cs
@@ -34,6 +34,7 @@ public class Resolver
     {
         _currentScope.Define("print", new VariableInfo("print", isReadOnly: true, _currentScope.Depth));
         _currentScope.Define("println", new VariableInfo("println", isReadOnly: true, _currentScope.Depth));
+        _currentScope.Define("typeof", new VariableInfo("typeof", isReadOnly: true, _currentScope.Depth));
     }
 
     /// <summary>
@@ -263,6 +264,9 @@ public class Resolver
                 break;
             case MatchExpr matchExpr:
                 ResolveMatchExpr(matchExpr);
+                break;
+            case InstanceOfExpr instanceOfExpr:
+                ResolveExpression(instanceOfExpr.Object);
                 break;
             default:
                 _errors.Add(new ResolveException(

--- a/src/Irooon.Core/Runtime/IroClass.cs
+++ b/src/Irooon.Core/Runtime/IroClass.cs
@@ -89,4 +89,19 @@ public class IroClass
         // 親クラスから検索
         return Parent?.GetMethod(name);
     }
+
+    /// <summary>
+    /// スタティックメソッドを取得します（親クラスも検索）
+    /// </summary>
+    /// <param name="name">メソッド名</param>
+    /// <returns>メソッド（見つからない場合はnull）</returns>
+    public IroCallable? GetStaticMethod(string name)
+    {
+        if (StaticMethods.TryGetValue(name, out var method))
+        {
+            return method;
+        }
+
+        return Parent?.GetStaticMethod(name);
+    }
 }

--- a/src/Irooon.Core/Runtime/ScriptContext.cs
+++ b/src/Irooon.Core/Runtime/ScriptContext.cs
@@ -93,6 +93,9 @@ public class ScriptContext
         // 日時
         Globals["now"] = new BuiltinFunction("now", RuntimeHelpers.Now);
 
+        // 型チェック
+        Globals["typeof"] = new BuiltinFunction("typeof", RuntimeHelpers.__typeOf);
+
         // 低レベルプリミティブ（stdlib.iro の基盤）
         Globals["__stringLength"] = new BuiltinFunction("__stringLength", RuntimeHelpers.__stringLength);
         Globals["__charAt"] = new BuiltinFunction("__charAt", RuntimeHelpers.__charAt);

--- a/tests/Irooon.Tests/CodeGen/CodeGenClassTests.cs
+++ b/tests/Irooon.Tests/CodeGen/CodeGenClassTests.cs
@@ -482,4 +482,79 @@ public class CodeGenClassTests
     }
 
     #endregion
+
+    #region スタティックメソッド呼び出しテスト
+
+    [Fact]
+    public void TestStaticMethod_SimpleCall()
+    {
+        var source = @"
+        class Calculator {
+            public static fn add(a, b) {
+                a + b
+            }
+        }
+        Calculator.add(3, 4)
+        ";
+        var result = CompileAndRun(source);
+        Assert.Equal(7.0, result);
+    }
+
+    [Fact]
+    public void TestStaticMethod_NoArgs()
+    {
+        var source = @"
+        class Factory {
+            public static fn create() {
+                42
+            }
+        }
+        Factory.create()
+        ";
+        var result = CompileAndRun(source);
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void TestStaticMethod_WithInstanceMethods()
+    {
+        var source = @"
+        class Counter {
+            public var value = 0
+
+            public static fn create(initial) {
+                let c = Counter()
+                c.value = initial
+                c
+            }
+
+            public fn getValue() {
+                value
+            }
+        }
+        let c = Counter.create(10)
+        c.getValue()
+        ";
+        var result = CompileAndRun(source);
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public void TestStaticMethod_Inherited()
+    {
+        var source = @"
+        class Base {
+            public static fn greet() {
+                ""hello""
+            }
+        }
+        class Child extends Base {
+        }
+        Child.greet()
+        ";
+        var result = CompileAndRun(source);
+        Assert.Equal("hello", result);
+    }
+
+    #endregion
 }

--- a/tests/Irooon.Tests/CodeGen/CodeGenTypeTests.cs
+++ b/tests/Irooon.Tests/CodeGen/CodeGenTypeTests.cs
@@ -1,0 +1,170 @@
+using Xunit;
+using Irooon.Core.CodeGen;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Tests.CodeGen;
+
+/// <summary>
+/// typeof / instanceof のテスト
+/// Issue #35: v0.11.0
+/// </summary>
+public class CodeGenTypeTests
+{
+    private object? ExecuteScript(string source)
+    {
+        var tokens = new Core.Lexer.Lexer(source).ScanTokens();
+        var ast = new Core.Parser.Parser(tokens).Parse();
+        var resolver = new Core.Resolver.Resolver();
+        resolver.Resolve(ast);
+
+        var generator = new CodeGenerator();
+        var compiled = generator.Compile(ast);
+        var ctx = new ScriptContext();
+        return compiled(ctx);
+    }
+
+    #region typeof テスト
+
+    [Fact]
+    public void TestTypeOf_Number()
+    {
+        var result = ExecuteScript("typeof(42)");
+        Assert.Equal("Number", result);
+    }
+
+    [Fact]
+    public void TestTypeOf_String()
+    {
+        var result = ExecuteScript(@"typeof(""hello"")");
+        Assert.Equal("String", result);
+    }
+
+    [Fact]
+    public void TestTypeOf_Boolean()
+    {
+        var result = ExecuteScript("typeof(true)");
+        Assert.Equal("Boolean", result);
+    }
+
+    [Fact]
+    public void TestTypeOf_Null()
+    {
+        var result = ExecuteScript("typeof(null)");
+        Assert.Equal("Null", result);
+    }
+
+    [Fact]
+    public void TestTypeOf_List()
+    {
+        var result = ExecuteScript("typeof([1, 2, 3])");
+        Assert.Equal("List", result);
+    }
+
+    [Fact]
+    public void TestTypeOf_Hash()
+    {
+        var result = ExecuteScript("typeof({ a: 1 })");
+        Assert.Equal("Hash", result);
+    }
+
+    [Fact]
+    public void TestTypeOf_Instance()
+    {
+        var source = @"
+        class Dog {
+        }
+        typeof(Dog())
+        ";
+        var result = ExecuteScript(source);
+        Assert.Equal("Dog", result);
+    }
+
+    [Fact]
+    public void TestTypeOf_Function()
+    {
+        var source = @"
+        fn add(a, b) { a + b }
+        typeof(add)
+        ";
+        var result = ExecuteScript(source);
+        Assert.Equal("Function", result);
+    }
+
+    #endregion
+
+    #region instanceof テスト
+
+    [Fact]
+    public void TestInstanceOf_True()
+    {
+        var source = @"
+        class Dog {
+        }
+        let d = Dog()
+        d instanceof Dog
+        ";
+        var result = ExecuteScript(source);
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void TestInstanceOf_False()
+    {
+        var source = @"
+        class Dog {
+        }
+        class Cat {
+        }
+        let d = Dog()
+        d instanceof Cat
+        ";
+        var result = ExecuteScript(source);
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void TestInstanceOf_Inheritance()
+    {
+        var source = @"
+        class Animal {
+        }
+        class Dog extends Animal {
+        }
+        let d = Dog()
+        d instanceof Animal
+        ";
+        var result = ExecuteScript(source);
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void TestInstanceOf_NonInstance()
+    {
+        var source = @"
+        class Dog {
+        }
+        42 instanceof Dog
+        ";
+        var result = ExecuteScript(source);
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void TestInstanceOf_InExpression()
+    {
+        var source = @"
+        class Dog {
+        }
+        let d = Dog()
+        if (d instanceof Dog) {
+            ""yes""
+        } else {
+            ""no""
+        }
+        ";
+        var result = ExecuteScript(source);
+        Assert.Equal("yes", result);
+    }
+
+    #endregion
+}

--- a/tests/Irooon.Tests/Runtime/IroClassTests.cs
+++ b/tests/Irooon.Tests/Runtime/IroClassTests.cs
@@ -149,6 +149,43 @@ public class IroClassTests
         Assert.False(field.IsStatic); // v0.1ではstaticフィールド未対応
     }
 
+    #region GetStaticMethod テスト
+
+    [Fact]
+    public void IroClass_GetStaticMethod_自クラスのスタティックメソッドを取得できる()
+    {
+        var method = new TestCallable();
+        var methodDef = new MethodDef("create", isPublic: true, isStatic: true, method);
+        var iroClass = new IroClass("TestClass", Array.Empty<FieldDef>(), new[] { methodDef });
+
+        var result = iroClass.GetStaticMethod("create");
+        Assert.NotNull(result);
+        Assert.Equal(method, result);
+    }
+
+    [Fact]
+    public void IroClass_GetStaticMethod_親クラスのスタティックメソッドを取得できる()
+    {
+        var method = new TestCallable();
+        var parentMethodDef = new MethodDef("create", isPublic: true, isStatic: true, method);
+        var parent = new IroClass("Parent", Array.Empty<FieldDef>(), new[] { parentMethodDef });
+        var child = new IroClass("Child", Array.Empty<FieldDef>(), Array.Empty<MethodDef>(), parent);
+
+        var result = child.GetStaticMethod("create");
+        Assert.NotNull(result);
+        Assert.Equal(method, result);
+    }
+
+    [Fact]
+    public void IroClass_GetStaticMethod_存在しないメソッドはnullを返す()
+    {
+        var iroClass = new IroClass("TestClass", Array.Empty<FieldDef>(), Array.Empty<MethodDef>());
+        var result = iroClass.GetStaticMethod("nonExistent");
+        Assert.Null(result);
+    }
+
+    #endregion
+
     // テスト用のIroCallable実装
     private class TestCallable : IroCallable
     {

--- a/tests/Irooon.Tests/Runtime/MathAndInputTests.cs
+++ b/tests/Irooon.Tests/Runtime/MathAndInputTests.cs
@@ -180,7 +180,7 @@ public class MathAndInputTests
         // input関数がグローバルに登録されていることを確認
         var engine = CreateEngine();
         var result = engine.Execute(@"__typeOf(input)");
-        Assert.Equal("BuiltinFunction", result);
+        Assert.Equal("Function", result);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- **静的メソッド呼び出し**: `Calculator.add(3, 4)` のようなクラスメソッド呼び出しに対応。クラスを `ctx.Globals` にも登録し、`GetMember()` に `IroClass` 分岐を追加
- **typeof ビルトイン関数**: `typeof(42)` → `"Number"` のように8種類の型名を返すビルトイン関数
- **instanceof 演算子**: `dog instanceof Animal` → `true` のように継承チェーンを辿った型チェック演算子

## Changes
- Lexer: `instanceof` キーワード追加
- AST: `InstanceOfExpr` ノード新規作成
- Parser: `Comparison()` に `instanceof` 処理追加
- Resolver: `InstanceOfExpr` 解析追加、`typeof` ビルトイン登録
- CodeGen: `GenerateInstanceOfExpr()` 追加、クラスを `ctx.Globals` にも登録
- Runtime: `IsInstanceOf()` / `GetStaticMethod()` 追加、`__typeOf` 拡張、`GetMember()` に `IroClass` 分岐追加

## Test plan
- [x] 静的メソッド呼び出しテスト 7件（単体3件 + 統合4件）
- [x] typeof テスト 8件（Number, String, Boolean, Null, List, Hash, Instance, Function）
- [x] instanceof テスト 5件（true, false, 継承, 非インスタンス, 式中使用）
- [x] 全回帰テスト 1,060件 GREEN

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)