### PR TITLE
fix: v0.11.1 - 5件のバグ修正

### DIFF
--- a/examples/lisp.iro
+++ b/examples/lisp.iro
@@ -232,25 +232,18 @@ var lispEval = null
 
 fn evalCond(expr, env) {
     var i = 1
-    var result = null
-    var found = false
-    for (i < expr.length() and found == false) {
+    for (i < expr.length()) {
         var clause = expr[i]
-        if (typeof(clause[0]) == "String" and clause[0] == "else") {
-            result = lispEval(clause[1], env)
-            found = true
-        } else {
-            var test = lispEval(clause[0], env)
-            if (test != false and test != null) {
-                result = lispEval(clause[1], env)
-                found = true
-            } else {
-                null
-            }
+        if (clause[0] == "else") {
+            return lispEval(clause[1], env)
+        }
+        var test = lispEval(clause[0], env)
+        if (test != false and test != null) {
+            return lispEval(clause[1], env)
         }
         i++
     }
-    result
+    null
 }
 
 fn evalLet(expr, env) {
@@ -266,33 +259,27 @@ fn evalLet(expr, env) {
 fn evalAnd(expr, env) {
     var result = true
     var i = 1
-    var done = false
-    for (i < expr.length() and done == false) {
+    for (i < expr.length()) {
         result = lispEval(expr[i], env)
         if (result == false or result == null) {
-            done = true
-        } else {
-            null
+            return false
         }
         i++
     }
-    if (done) { false } else { result }
+    result
 }
 
 fn evalOr(expr, env) {
     var result = false
     var i = 1
-    var found = false
-    for (i < expr.length() and found == false) {
+    for (i < expr.length()) {
         result = lispEval(expr[i], env)
         if (result != false and result != null) {
-            found = true
-        } else {
-            null
+            return result
         }
         i++
     }
-    result
+    false
 }
 
 fn evalList(expr, env) {

--- a/src/Irooon.Core/Ast/Expressions/IfExpr.cs
+++ b/src/Irooon.Core/Ast/Expressions/IfExpr.cs
@@ -17,19 +17,19 @@ public class IfExpr : Expression
     public Expression ThenBranch { get; }
 
     /// <summary>
-    /// 条件が偽の場合に評価される式
+    /// 条件が偽の場合に評価される式（省略可能、省略時はnull）
     /// </summary>
-    public Expression ElseBranch { get; }
+    public Expression? ElseBranch { get; }
 
     /// <summary>
     /// IfExprの新しいインスタンスを初期化します。
     /// </summary>
     /// <param name="condition">条件式</param>
     /// <param name="thenBranch">then節の式</param>
-    /// <param name="elseBranch">else節の式</param>
+    /// <param name="elseBranch">else節の式（省略可能）</param>
     /// <param name="line">行番号</param>
     /// <param name="column">列番号</param>
-    public IfExpr(Expression condition, Expression thenBranch, Expression elseBranch, int line, int column)
+    public IfExpr(Expression condition, Expression thenBranch, Expression? elseBranch, int line, int column)
         : base(line, column)
     {
         Condition = condition;

--- a/src/Irooon.Core/Parser/Parser.cs
+++ b/src/Irooon.Core/Parser/Parser.cs
@@ -835,20 +835,21 @@ public class Parser
         // 改行をスキップ
         while (Match(TokenType.Newline)) { }
 
-        // else は必須
-        Consume(TokenType.Else, "Expect 'else' after if then branch.");
-
-        // else if のシンタックスシュガー
-        Expression elseBranch;
-        if (Match(TokenType.If))
+        // else はオプショナル
+        Expression? elseBranch = null;
+        if (Match(TokenType.Else))
         {
-            elseBranch = IfExpression();
-        }
-        else
-        {
-            // else ブランチをパース（必ずブロック）
-            Consume(TokenType.LeftBrace, "Expect '{' after 'else'.");
-            elseBranch = BlockExpression();
+            // else if のシンタックスシュガー
+            if (Match(TokenType.If))
+            {
+                elseBranch = IfExpression();
+            }
+            else
+            {
+                // else ブランチをパース（必ずブロック）
+                Consume(TokenType.LeftBrace, "Expect '{' after 'else'.");
+                elseBranch = BlockExpression();
+            }
         }
 
         return new IfExpr(condition, thenBranch, elseBranch, ifToken.Line, ifToken.Column);

--- a/tests/Irooon.Tests/Parser/ParserStmtTests.cs
+++ b/tests/Irooon.Tests/Parser/ParserStmtTests.cs
@@ -129,7 +129,7 @@ if (x > 0) {
     }
 
     [Fact]
-    public void TestParseIfExprWithoutElse_ShouldThrowError()
+    public void TestParseIfExprWithoutElse_ShouldParse()
     {
         var source = @"
 if (x > 0) {
@@ -138,8 +138,9 @@ if (x > 0) {
         var tokens = new Core.Lexer.Lexer(source).ScanTokens();
         var parser = new Core.Parser.Parser(tokens);
 
-        // else が必須なので、ParseException が投げられるはず
-        Assert.Throws<ParseException>(() => parser.Parse());
+        // v0.11.1: else は省略可能
+        var ast = parser.Parse();
+        Assert.NotNull(ast);
     }
 
     [Fact]

--- a/tests/Irooon.Tests/Runtime/BugFixV0111Tests.cs
+++ b/tests/Irooon.Tests/Runtime/BugFixV0111Tests.cs
@@ -1,0 +1,283 @@
+using Xunit;
+using Irooon.Core;
+
+namespace Irooon.Tests.Runtime;
+
+/// <summary>
+/// v0.11.1 バグ修正テスト
+/// Issue #39
+/// </summary>
+public class BugFixV0111Tests
+{
+    private object? Execute(string source)
+    {
+        var engine = new ScriptEngine();
+        return engine.Execute(source);
+    }
+
+    #region 修正D: __toNumber() が非数値で例外
+
+    [Fact]
+    public void ToNumber_NonNumericString_ReturnsNull()
+    {
+        var result = Execute(@"__toNumber(""hello"")");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ToNumber_NumericString_ReturnsNumber()
+    {
+        var result = Execute(@"__toNumber(""42"")");
+        Assert.Equal(42.0, result);
+    }
+
+    #endregion
+
+    #region 修正B: == 演算子の型不一致例外
+
+    [Fact]
+    public void Eq_ListAndString_ReturnsFalse()
+    {
+        var result = Execute(@"[1, 2, 3] == ""hello""");
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void Eq_HashAndNumber_ReturnsFalse()
+    {
+        var result = Execute(@"{ a: 1 } == 42");
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void Ne_ListAndString_ReturnsTrue()
+    {
+        var result = Execute(@"[1, 2, 3] != ""hello""");
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void Lt_ListAndNumber_ThrowsException()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() => Execute(@"[1, 2] < 5"));
+        Assert.Contains("Cannot compare", ex.InnerException?.Message ?? ex.Message);
+    }
+
+    #endregion
+
+    #region 修正E: if式にelseが必須
+
+    [Fact]
+    public void If_WithoutElse_TrueReturnsValue()
+    {
+        var result = Execute("if (true) { 42 }");
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void If_WithoutElse_FalseReturnsNull()
+    {
+        var result = Execute("if (false) { 42 }");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void If_WithElse_StillWorks()
+    {
+        var result = Execute("if (true) { 1 } else { 2 }");
+        Assert.Equal(1.0, result);
+    }
+
+    #endregion
+
+    #region 修正C: returnがfor内で機能しない
+
+    [Fact]
+    public void Return_InsideForLoop_ExitsFunction()
+    {
+        var result = Execute(@"
+            fn findFirst(items) {
+                for (item in items) {
+                    if (item == 3) {
+                        return item
+                    }
+                }
+                return -1
+            }
+            findFirst([1, 2, 3, 4, 5])
+        ");
+        Assert.Equal(3.0, result);
+    }
+
+    [Fact]
+    public void Return_InsideForeachLoop_ExitsFunction()
+    {
+        var result = Execute(@"
+            fn contains(items, target) {
+                foreach (item in items) {
+                    if (item == target) {
+                        return true
+                    }
+                }
+                return false
+            }
+            contains([10, 20, 30], 20)
+        ");
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void Return_WithoutLoop_StillWorks()
+    {
+        var result = Execute(@"
+            fn double(x) {
+                return x * 2
+            }
+            double(21)
+        ");
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void Return_InNestedFunction_DoesNotAffectOuter()
+    {
+        var result = Execute(@"
+            fn outer() {
+                fn inner() {
+                    return 10
+                }
+                var x = inner()
+                return x + 5
+            }
+            outer()
+        ");
+        Assert.Equal(15.0, result);
+    }
+
+    #endregion
+
+    #region 修正A: this.method()ハング
+
+    [Fact]
+    public void ThisMethod_MultipleCallsNoHang()
+    {
+        // this.method() を複数回呼んでもハングしない
+        var result = Execute(@"
+            class Counter {
+                var count = 0
+
+                fn increment() {
+                    count = count + 1
+                }
+
+                fn addThree() {
+                    this.increment()
+                    this.increment()
+                    this.increment()
+                    return count
+                }
+            }
+            var c = Counter()
+            c.addThree()
+        ");
+        Assert.Equal(3.0, result);
+    }
+
+    [Fact]
+    public void ThisMethod_FieldChangePropagation()
+    {
+        // 内部メソッド呼び出しでのフィールド変更が外部に伝播する
+        var result = Execute(@"
+            class Acc {
+                var total = 0
+
+                fn add(n) {
+                    total = total + n
+                }
+
+                fn addTwice(n) {
+                    this.add(n)
+                    this.add(n)
+                    return total
+                }
+            }
+            var a = Acc()
+            a.addTwice(5)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public void ThisMethod_DifferentInstancesIsolated()
+    {
+        // 異なるインスタンスのフィールドは干渉しない
+        var result = Execute(@"
+            class Box {
+                var value = 0
+
+                fn set(v) {
+                    value = v
+                }
+
+                fn get() {
+                    return value
+                }
+            }
+            var a = Box()
+            var b = Box()
+            a.set(10)
+            b.set(20)
+            a.get() + b.get()
+        ");
+        Assert.Equal(30.0, result);
+    }
+
+    [Fact]
+    public void ThisMethod_Recursive()
+    {
+        // 再帰的な this.method() 呼び出し
+        var result = Execute(@"
+            class Factorial {
+                var result = 1
+
+                fn calc(n) {
+                    if (n <= 1) {
+                        return result
+                    }
+                    result = result * n
+                    return this.calc(n - 1)
+                }
+            }
+            var f = Factorial()
+            f.calc(5)
+        ");
+        Assert.Equal(120.0, result);
+    }
+
+    [Fact]
+    public void ThisMethod_ChainedCalls()
+    {
+        // メソッドチェーン的な連続呼び出し
+        var result = Execute(@"
+            class Builder {
+                var count = 0
+
+                fn addItem() {
+                    count = count + 1
+                }
+
+                fn build() {
+                    this.addItem()
+                    this.addItem()
+                    this.addItem()
+                    return count
+                }
+            }
+            var b = Builder()
+            b.build()
+        ");
+        Assert.Equal(3.0, result);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Lisp インタプリタ作成中に発見された irooon の既知バグ5件を修正するパッチリリース。

### 修正内容
- **修正A**: `this.method()` を複数回呼ぶとフィールド値が stale になりハングする問題を修正（smart sync-back + 再帰対応）
- **修正B**: `==` 演算子で List/Hash と他の型を比較すると `IConvertible` キャスト例外が発生する問題を修正
- **修正C**: `return` が `for`/`foreach` ループ内で関数を抜けない問題を修正（`_returnLabel` による `ExprTree.Return` 実装）
- **修正D**: `__toNumber()` が非数値文字列で `FormatException` をスローする問題を修正（null を返すように）
- **修正E**: `if` 式に `else` が必須だった制約を解除（else 省略時は null を返す）

### その他
- `examples/lisp.iro` から全ワークアラウンドを除去（return in loop、typeof ガード、フラグ変数パターン）
- 既存パーサーテストを修正E に合わせて更新

### テスト
- 18件の新規テスト（BugFixV0111Tests）
- 全 1,078 テストパス（回帰なし）

Closes #39

## Test plan
- [x] 全テスト回帰確認（1,078件パス）
- [x] `lisp.iro` ワークアラウンド除去後の動作確認（全セクション正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)