### PR TITLE
feat: v0.11.2 - export制限解除 + CLR相互運用拡張

### DIFF
--- a/src/Irooon.Core/Ast/Statements/AssemblyRefStmt.cs
+++ b/src/Irooon.Core/Ast/Statements/AssemblyRefStmt.cs
@@ -1,0 +1,18 @@
+namespace Irooon.Core.Ast;
+
+/// <summary>
+/// アセンブリ参照ディレクティブを表すASTノード。
+/// #r "path/to/assembly.dll"
+/// </summary>
+public class AssemblyRefStmt : Statement
+{
+    /// <summary>
+    /// アセンブリのパス
+    /// </summary>
+    public string AssemblyPath { get; }
+
+    public AssemblyRefStmt(string assemblyPath, int line, int column) : base(line, column)
+    {
+        AssemblyPath = assemblyPath;
+    }
+}

--- a/src/Irooon.Core/Lexer/TokenType.cs
+++ b/src/Irooon.Core/Lexer/TokenType.cs
@@ -94,6 +94,9 @@ public enum TokenType
     Dollar,         // $
     Backtick,       // `
 
+    // ディレクティブ
+    AssemblyRef,    // #r "path"
+
     // 特殊
     Newline,        // 改行（パーサーで必要な場合）
     Eof,            // End of File

--- a/src/Irooon.Core/Parser/Parser.cs
+++ b/src/Irooon.Core/Parser/Parser.cs
@@ -52,7 +52,7 @@ public class Parser
             bool isAsyncFunctionDef = Check(TokenType.Async);
 
             // 文をパース（async fn, 関数定義、クラス定義、変数宣言、モジュール）
-            if (isAsyncFunctionDef || isFunctionDef || Check(TokenType.Class) || Check(TokenType.Let) || Check(TokenType.Var) || Check(TokenType.For) || Check(TokenType.Foreach) || Check(TokenType.Break) || Check(TokenType.Continue) || Check(TokenType.Return) || Check(TokenType.Throw) || Check(TokenType.Export) || Check(TokenType.Import))
+            if (isAsyncFunctionDef || isFunctionDef || Check(TokenType.Class) || Check(TokenType.Let) || Check(TokenType.Var) || Check(TokenType.For) || Check(TokenType.Foreach) || Check(TokenType.Break) || Check(TokenType.Continue) || Check(TokenType.Return) || Check(TokenType.Throw) || Check(TokenType.Export) || Check(TokenType.Import) || Check(TokenType.AssemblyRef))
             {
                 statements.Add(Statement());
                 // 文の後の改行をスキップ
@@ -1094,6 +1094,12 @@ public class Parser
             return ImportStatement();
         }
 
+        if (Match(TokenType.AssemblyRef))
+        {
+            var token = Previous();
+            return new AssemblyRefStmt((string)token.Value!, token.Line, token.Column);
+        }
+
         // async fn の処理
         if (Match(TokenType.Async))
         {
@@ -1762,7 +1768,19 @@ public class Parser
             return new ExportStmt(funcDef, exportToken.Line, exportToken.Column);
         }
 
-        throw new ParseException(exportToken, "Expected 'let' or 'fn' after 'export'.");
+        if (Match(TokenType.Var))
+        {
+            var varStmt = VarStatement();
+            return new ExportStmt(varStmt, exportToken.Line, exportToken.Column);
+        }
+
+        if (Match(TokenType.Class))
+        {
+            var classDef = ClassDefinition();
+            return new ExportStmt(classDef, exportToken.Line, exportToken.Column);
+        }
+
+        throw new ParseException(exportToken, "Expected 'let', 'var', 'fn', or 'class' after 'export'.");
     }
 
     /// <summary>

--- a/src/Irooon.Core/Resolver/Resolver.cs
+++ b/src/Irooon.Core/Resolver/Resolver.cs
@@ -542,6 +542,9 @@ public class Resolver
             case ImportStmt importStmt:
                 ResolveImportStmt(importStmt);
                 break;
+            case AssemblyRefStmt:
+                // アセンブリ参照はスコープ解析不要
+                break;
             default:
                 _errors.Add(new ResolveException(
                     $"Unknown statement type: {stmt.GetType().Name}",

--- a/tests/Irooon.Tests/Lexer/LexerTests.cs
+++ b/tests/Irooon.Tests/Lexer/LexerTests.cs
@@ -1055,4 +1055,50 @@ git push
     }
 
     #endregion
+
+    #region アセンブリ参照ディレクティブ (#r)
+
+    [Fact]
+    public void TestAssemblyRef_Basic()
+    {
+        var lexer = new Core.Lexer.Lexer("#r \"path/to/assembly.dll\"");
+        var tokens = lexer.ScanTokens();
+
+        Assert.Equal(2, tokens.Count); // AssemblyRef + Eof
+        Assert.Equal(TokenType.AssemblyRef, tokens[0].Type);
+        Assert.Equal("path/to/assembly.dll", tokens[0].Value);
+    }
+
+    [Fact]
+    public void TestAssemblyRef_WithSpaces()
+    {
+        var lexer = new Core.Lexer.Lexer("#r   \"my assembly.dll\"");
+        var tokens = lexer.ScanTokens();
+
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenType.AssemblyRef, tokens[0].Type);
+        Assert.Equal("my assembly.dll", tokens[0].Value);
+    }
+
+    [Fact]
+    public void TestAssemblyRef_Unterminated()
+    {
+        var lexer = new Core.Lexer.Lexer("#r \"unterminated");
+        var tokens = lexer.ScanTokens();
+
+        // エラーが発生してもEofトークンは生成される
+        Assert.Contains(tokens, t => t.Type == TokenType.Eof);
+    }
+
+    [Fact]
+    public void TestAssemblyRef_InvalidDirective()
+    {
+        var lexer = new Core.Lexer.Lexer("#x \"something\"");
+        var tokens = lexer.ScanTokens();
+
+        // #r 以外はエラー → AssemblyRefトークンは生成されない
+        Assert.DoesNotContain(tokens, t => t.Type == TokenType.AssemblyRef);
+    }
+
+    #endregion
 }

--- a/tests/Irooon.Tests/Runtime/ModuleTests.cs
+++ b/tests/Irooon.Tests/Runtime/ModuleTests.cs
@@ -109,4 +109,41 @@ public class ModuleTests
         var result = ExecuteWithModule(module, "cached.iro", main);
         Assert.Equal(42.0, result);
     }
+
+    [Fact]
+    public void Import_ExportedVar()
+    {
+        var module = @"
+            export var counter = 99
+        ";
+
+        var main = @"
+            import { counter } from ""./state.iro""
+            counter
+        ";
+
+        var result = ExecuteWithModule(module, "state.iro", main);
+        Assert.Equal(99.0, result);
+    }
+
+    [Fact]
+    public void Import_ExportedClass()
+    {
+        var module = @"
+            export class Calculator {
+                fn add(a, b) {
+                    a + b
+                }
+            }
+        ";
+
+        var main = @"
+            import { Calculator } from ""./calc.iro""
+            var c = Calculator()
+            c.add(3, 4)
+        ";
+
+        var result = ExecuteWithModule(module, "calc.iro", main);
+        Assert.Equal(7.0, result);
+    }
 }


### PR DESCRIPTION
## Summary
- `export var` / `export class` をサポート（既存の `let`, `fn` に加えて4種類すべて対応）
- CLR相互運用の `System.*` 名前空間制限を解除し、任意の .NET 型が利用可能に
- `ResolveCLRType` にキャッシュ（`ConcurrentDictionary`）を追加してパフォーマンス改善
- `#r "path/to/assembly.dll"` ディレクティブによる外部アセンブリの明示読込を追加
- `import` 時に `IroClass` を `ctx.Classes` にも登録するよう修正

## Test plan
- [x] export var / class のパーサーテスト（2件）
- [x] export var / class のE2Eテスト（2件）
- [x] CLR System型の回帰テスト（1件）
- [x] #r ディレクティブのLexerテスト（4件）
- [x] #r ディレクティブのParserテスト（2件）
- [x] #r ディレクティブのE2Eテスト（2件）
- [x] 全1,091テスト合格（回帰なし）

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)