### PR TITLE
feat: v0.12.0 - async/await 完全実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-02-10
+
+### Changed
+- **async/await 完全実装** (#45)
+  - `async fn` が `Task.Run` ベースの真の並行実行に（旧: `Task.FromResult` でブロッキング）
+  - `await` が CLR の `Task<T>` を直接サポート（リフレクションで Result を取得）
+  - async 関数はクローンされた `ScriptContext` で実行（スコープ分離）
+  - `CodeGenerator.GenerateAsyncFunctionDef()` を削除し、同期/非同期で同一コード生成パスに統合
+  - `WrapInTask()` を削除
+
+### Added
+- **`delay(ms)` ビルトイン** — 指定ミリ秒後に完了する Task を返す
+- **`awaitAll([tasks])` ビルトイン** — 全 Task の完了を待ち、結果リストを返す
+- **`ScriptContext.Clone()`** — async 関数のスコープ分離用コンテキストクローン
+- **`Closure.IsAsync`** — 非同期関数フラグ
+
 ## [0.11.3] - 2026-02-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ println("Abs:", abs, "Sqrt:", sqrt, "Now:", now)
 
 ## 開発状況
 
-現在のバージョン: **v0.11.3**
+現在のバージョン: **v0.12.0**
 
 変更履歴は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -787,6 +787,17 @@ typeof({a: 1})        // "Hash"
 typeof(fn (x) { x })  // "Function"
 ```
 
+### delay / awaitAll
+
+```iro
+// delay(ms) — 指定ミリ秒後に完了する Task を返す
+await delay(1000)
+
+// awaitAll([tasks]) — 全 Task の完了を待ち、結果リストを返す
+async fn compute(x) { x * 2 }
+let results = awaitAll([compute(1), compute(2), compute(3)])  // [2, 4, 6]
+```
+
 ---
 
 ## 16. CLR 相互運用
@@ -848,9 +859,23 @@ async fn fetchData() {
 }
 ```
 
-- `async fn` で非同期関数を定義
+- `async fn` で非同期関数を定義（`Task.Run` ベースの真の並行実行）
 - `await` で非同期結果を待機
-- 内部的にはブロッキング実行
+- async 関数はクローンされたスコープで実行される（呼び出し元に副作用なし）
+- CLR の `Task<T>` も直接 `await` 可能
+
+### ビルトイン非同期ユーティリティ
+
+```iro
+// delay(ms) — 指定ミリ秒後に完了する Task を返す
+let task = delay(1000)
+await task
+
+// awaitAll([tasks]) — 全 Task の完了を待ち、結果リストを返す
+async fn double(x) { x * 2 }
+let tasks = [double(1), double(2), double(3)]
+let results = awaitAll(tasks)  // [2, 4, 6]
+```
 
 ---
 

--- a/src/Irooon.Core/Runtime/Closure.cs
+++ b/src/Irooon.Core/Runtime/Closure.cs
@@ -33,6 +33,11 @@ public class Closure : IroCallable
     public int Column { get; }
 
     /// <summary>
+    /// 非同期関数かどうか
+    /// </summary>
+    public bool IsAsync { get; }
+
+    /// <summary>
     /// 関数本体
     /// </summary>
     private readonly Func<ScriptContext, object[], object> _body;
@@ -45,7 +50,9 @@ public class Closure : IroCallable
     /// <param name="parameterNames">パラメータ名のリスト（省略可能）</param>
     /// <param name="line">関数定義の行番号</param>
     /// <param name="column">関数定義の列番号</param>
-    public Closure(string name, Func<ScriptContext, object[], object> body, List<string>? parameterNames = null, int line = 0, int column = 0, List<string>? localNames = null)
+    /// <param name="localNames">ローカル変数名のリスト（省略可能）</param>
+    /// <param name="isAsync">非同期関数かどうか</param>
+    public Closure(string name, Func<ScriptContext, object[], object> body, List<string>? parameterNames = null, int line = 0, int column = 0, List<string>? localNames = null, bool isAsync = false)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         _body = body ?? throw new ArgumentNullException(nameof(body));
@@ -53,6 +60,7 @@ public class Closure : IroCallable
         Line = line;
         Column = column;
         LocalNames = localNames ?? new List<string>();
+        IsAsync = isAsync;
     }
 
     /// <summary>

--- a/src/Irooon.Core/Runtime/ScriptContext.cs
+++ b/src/Irooon.Core/Runtime/ScriptContext.cs
@@ -51,6 +51,22 @@ public class ScriptContext
     }
 
     /// <summary>
+    /// コンテキストのクローンを作成する（async関数のスコープ分離用）
+    /// Globals はシャローコピー、Classes/Prototypes は参照共有
+    /// </summary>
+    public ScriptContext Clone()
+    {
+        var clone = new ScriptContext();
+        foreach (var kv in Globals)
+            clone.Globals[kv.Key] = kv.Value;
+        foreach (var kv in Classes)
+            clone.Classes[kv.Key] = kv.Value;
+        foreach (var kv in Prototypes)
+            clone.Prototypes[kv.Key] = kv.Value;
+        return clone;
+    }
+
+    /// <summary>
     /// 標準ライブラリを初期化する（ScriptEngine経由で一度だけ呼ばれる）
     /// </summary>
     public void InitializeStdlib(Action<string, ScriptContext> executeFunc)
@@ -95,6 +111,10 @@ public class ScriptContext
 
         // 型チェック
         Globals["typeof"] = new BuiltinFunction("typeof", RuntimeHelpers.__typeOf);
+
+        // 非同期ユーティリティ
+        Globals["delay"] = new BuiltinFunction("delay", RuntimeHelpers.Delay);
+        Globals["awaitAll"] = new BuiltinFunction("awaitAll", RuntimeHelpers.AwaitAll);
 
         // 低レベルプリミティブ（stdlib.iro の基盤）
         Globals["__stringLength"] = new BuiltinFunction("__stringLength", RuntimeHelpers.__stringLength);

--- a/tests/Irooon.Tests/CodeGen/AsyncAwaitTests.cs
+++ b/tests/Irooon.Tests/CodeGen/AsyncAwaitTests.cs
@@ -1,0 +1,208 @@
+using Xunit;
+using Irooon.Core.CodeGen;
+using Irooon.Core.Runtime;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Irooon.Tests.CodeGen;
+
+/// <summary>
+/// async/await 完全実装テスト
+/// v0.12.0: 真の非同期実行（Task.Run ベース）
+/// </summary>
+public class AsyncAwaitTests
+{
+    private object? ExecuteScript(string source)
+    {
+        var tokens = new Core.Lexer.Lexer(source).ScanTokens();
+        var ast = new Core.Parser.Parser(tokens).Parse();
+        var resolver = new Core.Resolver.Resolver();
+        resolver.Resolve(ast);
+
+        var generator = new CodeGenerator();
+        var compiled = generator.Compile(ast);
+        var ctx = new ScriptContext();
+        return compiled(ctx);
+    }
+
+    #region 基本テスト
+
+    [Fact]
+    public void TestAsyncFunction_ReturnsTask()
+    {
+        // async fn は Task<object> を返すべき
+        var result = ExecuteScript(@"
+            async fn hello() {
+                42
+            }
+            hello()
+        ");
+        Assert.IsAssignableFrom<Task>(result);
+    }
+
+    [Fact]
+    public void TestAwait_GetsResult()
+    {
+        // await で Task の結果を取得
+        var result = ExecuteScript(@"
+            async fn compute() {
+                42
+            }
+            let t = compute()
+            await t
+        ");
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void TestAsyncFunction_RunsConcurrently()
+    {
+        // 複数の async fn が並行実行され、全ての結果を取得できることを確認
+        var result = ExecuteScript(@"
+            async fn compute(x) { x * 2 }
+            let t1 = compute(5)
+            let t2 = compute(10)
+            let t3 = compute(15)
+            let r1 = await t1
+            let r2 = await t2
+            let r3 = await t3
+            let results = [r1, r2, r3]
+            results
+        ");
+        Assert.IsType<List<object>>(result);
+        var list = (List<object>)result!;
+        Assert.Equal(3, list.Count);
+        Assert.Equal(10.0, list[0]);
+        Assert.Equal(20.0, list[1]);
+        Assert.Equal(30.0, list[2]);
+    }
+
+    #endregion
+
+    #region delay / awaitAll テスト
+
+    [Fact]
+    public void TestDelay_ReturnsTask()
+    {
+        // delay(ms) が Task を返す
+        var result = ExecuteScript(@"
+            delay(10)
+        ");
+        Assert.IsAssignableFrom<Task>(result);
+    }
+
+    [Fact]
+    public void TestAwaitAll_WaitsForAllTasks()
+    {
+        // awaitAll が全タスクの完了を待つ
+        var result = ExecuteScript(@"
+            async fn task1() { 1 }
+            async fn task2() { 2 }
+            async fn task3() { 3 }
+            let tasks = [task1(), task2(), task3()]
+            let results = awaitAll(tasks)
+            results
+        ");
+        Assert.IsType<List<object>>(result);
+        var list = (List<object>)result!;
+        Assert.Equal(3, list.Count);
+    }
+
+    [Fact]
+    public void TestAwaitAll_CollectsResults()
+    {
+        // awaitAll が結果リストを正しく返す
+        var result = ExecuteScript(@"
+            async fn double(x) { x * 2 }
+            let tasks = [double(5), double(10), double(15)]
+            awaitAll(tasks)
+        ");
+        Assert.IsType<List<object>>(result);
+        var list = (List<object>)result!;
+        Assert.Equal(3, list.Count);
+        Assert.Equal(10.0, list[0]);
+        Assert.Equal(20.0, list[1]);
+        Assert.Equal(30.0, list[2]);
+    }
+
+    #endregion
+
+    #region CLR Task サポート
+
+    [Fact]
+    public void TestAwait_CLRTask()
+    {
+        // CLR の Task<T> を await 可能
+        // delay() は Task<object> を返すので、CLR Task として扱える
+        var result = ExecuteScript(@"
+            let task = delay(1)
+            let r = await task
+            r
+        ");
+        // delay は null を返す
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TestAwait_CLRTask_WithResult()
+    {
+        // ScriptContext に直接 CLR Task を注入してテスト
+        var tokens = new Core.Lexer.Lexer("await clrTask").ScanTokens();
+        var ast = new Core.Parser.Parser(tokens).Parse();
+        var resolver = new Core.Resolver.Resolver();
+        resolver.Resolve(ast);
+
+        var generator = new CodeGenerator();
+        var compiled = generator.Compile(ast);
+        var ctx = new ScriptContext();
+        // Task<string> を直接注入
+        ctx.Globals["clrTask"] = System.Threading.Tasks.Task.FromResult<string>("hello from CLR");
+        var result = compiled(ctx);
+        Assert.Equal("hello from CLR", result);
+    }
+
+    [Fact]
+    public void TestAwait_NonTask_PassThrough()
+    {
+        // Task でない値は await してもそのまま返る
+        var result = ExecuteScript(@"
+            await 42
+        ");
+        Assert.Equal(42.0, result);
+    }
+
+    #endregion
+
+    #region スコープ分離テスト
+
+    [Fact]
+    public void TestAsyncFunction_AccessesOuterScope()
+    {
+        // クローンされたスコープから外部変数を参照できる
+        var result = ExecuteScript(@"
+            let x = 100
+            async fn getX() { x }
+            await getX()
+        ");
+        Assert.Equal(100.0, result);
+    }
+
+    [Fact]
+    public void TestAsyncFunction_IsolatedScope()
+    {
+        // async 内の変更が呼び出し元の変数に影響しない
+        var result = ExecuteScript(@"
+            var x = 10
+            async fn modify() {
+                x = 999
+                x
+            }
+            let inner = await modify()
+            x
+        ");
+        // async 関数はクローンされたスコープで動くので、元の x は変わらない
+        Assert.Equal(10.0, result);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- 偽装 async（`Task.FromResult` + `.Wait()`）を `Task.Run` ベースの真の並行実行に置き換え
- `ScriptContext.Clone()` で async 関数のスコープ分離を実現
- `AwaitTask()` を CLR `Task<T>` 対応に書き換え
- `CodeGenerator.GenerateAsyncFunctionDef()` を削除し、同期/非同期で同一コード生成パスに統合
- `delay(ms)` / `awaitAll([tasks])` ビルトイン追加

## Test plan

- [x] 11件の新規テスト（AsyncAwaitTests.cs）全て合格
- [x] 全1,108テスト（1,096 + 12 REPL）合格
- [x] async fn が Task<object> を返すことを確認
- [x] await で結果を取得できることを確認
- [x] CLR Task<T> を await 可能なことを確認
- [x] async 関数のスコープ分離を確認
- [x] delay / awaitAll の動作を確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)