### PR TITLE
feat: v0.12.1 - async lambda 実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-02-10
+
+### Added
+- **async lambda** (#47)
+  - `async (x) => x * 2` — アロー形式
+  - `async (x) => { ... }` — ブロック形式
+  - `async x => x + 1` — 単一パラメータ
+  - `async () => 42` — パラメータなし
+- `LambdaExpr.IsAsync` プロパティ追加
+
 ## [0.12.0] - 2026-02-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ println("Abs:", abs, "Sqrt:", sqrt, "Now:", now)
 
 ## 開発状況
 
-現在のバージョン: **v0.12.0**
+現在のバージョン: **v0.12.1**
 
 変更履歴は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -864,6 +864,18 @@ async fn fetchData() {
 - async 関数はクローンされたスコープで実行される（呼び出し元に副作用なし）
 - CLR の `Task<T>` も直接 `await` 可能
 
+### async lambda
+
+```iro
+let f = async (x) => x * 2
+let g = async (x, y) => { x + y }
+let h = async x => x + 1
+let i = async () => 42
+
+await f(5)    // 10
+await h(41)   // 42
+```
+
 ### ビルトイン非同期ユーティリティ
 
 ```iro

--- a/src/Irooon.Core/Ast/Expressions/LambdaExpr.cs
+++ b/src/Irooon.Core/Ast/Expressions/LambdaExpr.cs
@@ -16,16 +16,23 @@ public class LambdaExpr : Expression
     public Expression Body { get; }
 
     /// <summary>
+    /// 非同期ラムダかどうか
+    /// </summary>
+    public bool IsAsync { get; }
+
+    /// <summary>
     /// LambdaExprの新しいインスタンスを初期化します。
     /// </summary>
     /// <param name="parameters">パラメータのリスト</param>
     /// <param name="body">関数本体</param>
     /// <param name="line">行番号</param>
     /// <param name="column">列番号</param>
-    public LambdaExpr(List<Parameter> parameters, Expression body, int line, int column)
+    /// <param name="isAsync">非同期ラムダかどうか</param>
+    public LambdaExpr(List<Parameter> parameters, Expression body, int line, int column, bool isAsync = false)
         : base(line, column)
     {
         Parameters = parameters;
         Body = body;
+        IsAsync = isAsync;
     }
 }

--- a/src/Irooon.Core/CodeGen/CodeGenerator.cs
+++ b/src/Irooon.Core/CodeGen/CodeGenerator.cs
@@ -1052,7 +1052,7 @@ public class CodeGenerator
             ExprTree.Constant(expr.Line),
             ExprTree.Constant(expr.Column),
             localNamesListNew,
-            ExprTree.Constant(false) // lambda は同期
+            ExprTree.Constant(expr.IsAsync)
         );
 
         return ExprTree.Convert(closureNew, typeof(object));

--- a/tests/Irooon.Tests/CodeGen/AsyncAwaitTests.cs
+++ b/tests/Irooon.Tests/CodeGen/AsyncAwaitTests.cs
@@ -205,4 +205,99 @@ public class AsyncAwaitTests
     }
 
     #endregion
+
+    #region async lambda テスト
+
+    [Fact]
+    public void TestAsyncLambda_ReturnsTask()
+    {
+        // async (x) => expr が Task を返す
+        var result = ExecuteScript(@"
+            let f = async (x) => x * 2
+            f(5)
+        ");
+        Assert.IsAssignableFrom<Task>(result);
+    }
+
+    [Fact]
+    public void TestAsyncLambda_AwaitResult()
+    {
+        // await で async lambda の結果を取得
+        var result = ExecuteScript(@"
+            let f = async (x) => x * 2
+            await f(5)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public void TestAsyncLambda_WithBlock()
+    {
+        // async (x) => { ... } ブロック形式
+        var result = ExecuteScript(@"
+            let f = async (x) => {
+                let y = x + 1
+                y * 2
+            }
+            await f(10)
+        ");
+        Assert.Equal(22.0, result);
+    }
+
+    [Fact]
+    public void TestAsyncLambda_SingleParam()
+    {
+        // async x => expr 単一パラメータ
+        var result = ExecuteScript(@"
+            let f = async x => x + 1
+            await f(41)
+        ");
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void TestAsyncLambda_NoParams()
+    {
+        // async () => expr パラメータなし
+        var result = ExecuteScript(@"
+            let f = async () => 42
+            await f()
+        ");
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void TestAsyncLambda_IsolatedScope()
+    {
+        // async lambda のスコープ分離
+        var result = ExecuteScript(@"
+            var x = 10
+            let f = async () => {
+                x = 999
+                x
+            }
+            let inner = await f()
+            x
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public void TestAsyncLambda_WithAwaitAll()
+    {
+        // awaitAll と async lambda の組み合わせ
+        var result = ExecuteScript(@"
+            let double = async (x) => x * 2
+            let tasks = [double(1), double(2), double(3)]
+            awaitAll(tasks)
+        ");
+        Assert.IsType<List<object>>(result);
+        var list = (List<object>)result!;
+        Assert.Equal(3, list.Count);
+        Assert.Equal(2.0, list[0]);
+        Assert.Equal(4.0, list[1]);
+        Assert.Equal(6.0, list[2]);
+    }
+
+    #endregion
 }

--- a/tests/Irooon.Tests/Parser/ParserExprTests.cs
+++ b/tests/Irooon.Tests/Parser/ParserExprTests.cs
@@ -1641,4 +1641,55 @@ public class ParserExprTests
     }
 
     #endregion
+
+    #region async lambda パーステスト
+
+    [Fact]
+    public void TestParseAsyncLambda_Parenthesized()
+    {
+        // async (x) => x
+        var tokens = new Core.Lexer.Lexer("async (x) => x").ScanTokens();
+        var parser = new Core.Parser.Parser(tokens);
+        var ast = parser.Parse();
+
+        Assert.NotNull(ast.Expression);
+        Assert.IsType<LambdaExpr>(ast.Expression);
+        var lambda = (LambdaExpr)ast.Expression;
+        Assert.True(lambda.IsAsync);
+        Assert.Single(lambda.Parameters);
+        Assert.Equal("x", lambda.Parameters[0].Name);
+    }
+
+    [Fact]
+    public void TestParseAsyncLambda_SingleParam()
+    {
+        // async x => x
+        var tokens = new Core.Lexer.Lexer("async x => x").ScanTokens();
+        var parser = new Core.Parser.Parser(tokens);
+        var ast = parser.Parse();
+
+        Assert.NotNull(ast.Expression);
+        Assert.IsType<LambdaExpr>(ast.Expression);
+        var lambda = (LambdaExpr)ast.Expression;
+        Assert.True(lambda.IsAsync);
+        Assert.Single(lambda.Parameters);
+        Assert.Equal("x", lambda.Parameters[0].Name);
+    }
+
+    [Fact]
+    public void TestParseAsyncLambda_NoParams()
+    {
+        // async () => 42
+        var tokens = new Core.Lexer.Lexer("async () => 42").ScanTokens();
+        var parser = new Core.Parser.Parser(tokens);
+        var ast = parser.Parse();
+
+        Assert.NotNull(ast.Expression);
+        Assert.IsType<LambdaExpr>(ast.Expression);
+        var lambda = (LambdaExpr)ast.Expression;
+        Assert.True(lambda.IsAsync);
+        Assert.Empty(lambda.Parameters);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- `async (x) => expr` / `async x => expr` / `async () => 42` 形式の async lambda をサポート
- `LambdaExpr.IsAsync` プロパティ追加
- Parser で async lambda を式としてパース（`async fn` のみステートメント扱い）
- CodeGenerator で `expr.IsAsync` を Closure に渡す

## Test plan

- [x] Parser テスト 3件（括弧付き/単一パラメータ/パラメータなし）
- [x] E2E テスト 7件（ReturnsTask/AwaitResult/WithBlock/SingleParam/NoParams/IsolatedScope/WithAwaitAll）
- [x] 全1,118テスト合格

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)