### PR TITLE
feat: v0.12.2 - 型アノテーション実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-02-10
+
+### Added
+- **型アノテーション** (#49)
+  - パラメータ型: `fn add(a: Number, b: Number) { a + b }`
+  - 戻り値型: `fn add(a, b): Number { a + b }`
+  - fn ラムダ: `fn (x: Number): String { "${x}" }`
+  - アロー関数パラメータ型: `(x: Number) => x * 2`
+  - クラスメソッド型: `public fn add(a: Number, b: Number): Number { a + b }`
+  - ユーザー定義クラスを型として使用: `fn getAge(p: Person): Number { ... }`
+  - 型不一致時に `RuntimeException` をスロー
+  - サポート型: Number, String, Boolean, Null, List, Hash, Function + クラス名
+- `RuntimeHelpers.GetTypeName()` 共通ヘルパー
+- `RuntimeHelpers.CheckType()` パラメータ型チェック
+- `RuntimeHelpers.CheckReturnType()` 戻り値型チェック
+
 ## [0.12.1] - 2026-02-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ fn add(a, b) {
 }
 
 let multiply = fn (x, y) { x * y }
+
+// 型アノテーション
+fn add(a: Number, b: Number): Number { a + b }
+let greet = (name: String) => "Hello, " + name
 ```
 
 ### クラス
@@ -388,7 +392,7 @@ println("Abs:", abs, "Sqrt:", sqrt, "Now:", now)
 
 ## 開発状況
 
-現在のバージョン: **v0.12.1**
+現在のバージョン: **v0.12.2**
 
 変更履歴は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -434,6 +434,56 @@ fn add(a, b, c) { a + b + c }
 add(...args)  // 6
 ```
 
+### 型アノテーション
+
+パラメータと戻り値に型注釈を付けることができます。型が一致しない場合、実行時エラーになります。
+
+```iro
+// パラメータ型 + 戻り値型
+fn add(a: Number, b: Number): Number {
+    a + b
+}
+
+// 部分的なアノテーション（一部だけ型指定も可）
+fn process(data, limit: Number) {
+    data
+}
+
+// デフォルト値との組み合わせ
+fn greet(name: String = "World"): String {
+    "Hello, " + name
+}
+
+// fn ラムダ式
+let f = fn (x: Number): String { "${x}" }
+
+// アロー関数（パラメータ型のみ、戻り値型は不可）
+let g = (x: Number) => x * 2
+
+// クラスメソッド
+class Calculator {
+    public fn add(a: Number, b: Number): Number { a + b }
+}
+
+// ユーザー定義クラスを型として使用
+fn getAge(person: Person): Number { person.age }
+```
+
+**サポートされる型名:**
+- `Number` — 数値（double）
+- `String` — 文字列
+- `Boolean` — 真偽値
+- `Null` — null
+- `List` — リスト
+- `Hash` — ハッシュ
+- `Function` — 関数/クロージャ
+- ユーザー定義クラス名（例: `Person`, `Animal`）
+
+**制限事項:**
+- ジェネリクスは非サポート（`List<Number>` 等は不可）
+- アロー関数に戻り値型アノテーションは不可
+- 括弧なし単一パラメータ `x => expr` には型アノテーション不可
+
 ### クロージャ
 
 ```iro

--- a/src/Irooon.Core/Ast/Expressions/LambdaExpr.cs
+++ b/src/Irooon.Core/Ast/Expressions/LambdaExpr.cs
@@ -21,6 +21,11 @@ public class LambdaExpr : Expression
     public bool IsAsync { get; }
 
     /// <summary>
+    /// 戻り値の型注釈（オプション）。例: "Number", "String"
+    /// </summary>
+    public string? ReturnType { get; }
+
+    /// <summary>
     /// LambdaExprの新しいインスタンスを初期化します。
     /// </summary>
     /// <param name="parameters">パラメータのリスト</param>
@@ -28,11 +33,13 @@ public class LambdaExpr : Expression
     /// <param name="line">行番号</param>
     /// <param name="column">列番号</param>
     /// <param name="isAsync">非同期ラムダかどうか</param>
-    public LambdaExpr(List<Parameter> parameters, Expression body, int line, int column, bool isAsync = false)
+    /// <param name="returnType">戻り値の型注釈（オプション）</param>
+    public LambdaExpr(List<Parameter> parameters, Expression body, int line, int column, bool isAsync = false, string? returnType = null)
         : base(line, column)
     {
         Parameters = parameters;
         Body = body;
         IsAsync = isAsync;
+        ReturnType = returnType;
     }
 }

--- a/src/Irooon.Core/Ast/MethodDef.cs
+++ b/src/Irooon.Core/Ast/MethodDef.cs
@@ -31,6 +31,11 @@ public class MethodDef : AstNode
     public Expression Body { get; }
 
     /// <summary>
+    /// 戻り値の型注釈（オプション）。例: "Number", "String"
+    /// </summary>
+    public string? ReturnType { get; }
+
+    /// <summary>
     /// MethodDefの新しいインスタンスを初期化します。
     /// </summary>
     /// <param name="name">メソッド名</param>
@@ -40,7 +45,8 @@ public class MethodDef : AstNode
     /// <param name="body">メソッド本体</param>
     /// <param name="line">行番号</param>
     /// <param name="column">列番号</param>
-    public MethodDef(string name, bool isPublic, bool isStatic, List<Parameter> parameters, Expression body, int line, int column)
+    /// <param name="returnType">戻り値の型注釈（オプション）</param>
+    public MethodDef(string name, bool isPublic, bool isStatic, List<Parameter> parameters, Expression body, int line, int column, string? returnType = null)
         : base(line, column)
     {
         Name = name;
@@ -48,5 +54,6 @@ public class MethodDef : AstNode
         IsStatic = isStatic;
         Parameters = parameters;
         Body = body;
+        ReturnType = returnType;
     }
 }

--- a/src/Irooon.Core/Ast/Parameter.cs
+++ b/src/Irooon.Core/Ast/Parameter.cs
@@ -21,6 +21,11 @@ public class Parameter : AstNode
     public bool IsRest { get; }
 
     /// <summary>
+    /// 型注釈（オプション）。例: "Number", "String", "Person"
+    /// </summary>
+    public string? TypeAnnotation { get; }
+
+    /// <summary>
     /// Parameterの新しいインスタンスを初期化します。
     /// </summary>
     /// <param name="name">パラメータ名</param>
@@ -28,10 +33,12 @@ public class Parameter : AstNode
     /// <param name="column">列番号</param>
     /// <param name="defaultValue">デフォルト値（オプション）</param>
     /// <param name="isRest">レストパラメータかどうか</param>
-    public Parameter(string name, int line, int column, Expression? defaultValue = null, bool isRest = false) : base(line, column)
+    /// <param name="typeAnnotation">型注釈（オプション）</param>
+    public Parameter(string name, int line, int column, Expression? defaultValue = null, bool isRest = false, string? typeAnnotation = null) : base(line, column)
     {
         Name = name;
         DefaultValue = defaultValue;
         IsRest = isRest;
+        TypeAnnotation = typeAnnotation;
     }
 }

--- a/src/Irooon.Core/Ast/Statements/FunctionDef.cs
+++ b/src/Irooon.Core/Ast/Statements/FunctionDef.cs
@@ -26,6 +26,11 @@ public class FunctionDef : Statement
     public bool IsAsync { get; }
 
     /// <summary>
+    /// 戻り値の型注釈（オプション）。例: "Number", "String"
+    /// </summary>
+    public string? ReturnType { get; }
+
+    /// <summary>
     /// FunctionDefの新しいインスタンスを初期化します。
     /// </summary>
     /// <param name="name">関数名</param>
@@ -34,12 +39,14 @@ public class FunctionDef : Statement
     /// <param name="line">行番号</param>
     /// <param name="column">列番号</param>
     /// <param name="isAsync">非同期関数かどうか（デフォルト: false）</param>
-    public FunctionDef(string name, List<Parameter> parameters, Expression body, int line, int column, bool isAsync = false)
+    /// <param name="returnType">戻り値の型注釈（オプション）</param>
+    public FunctionDef(string name, List<Parameter> parameters, Expression body, int line, int column, bool isAsync = false, string? returnType = null)
         : base(line, column)
     {
         Name = name;
         Parameters = parameters;
         Body = body;
         IsAsync = isAsync;
+        ReturnType = returnType;
     }
 }

--- a/tests/Irooon.Tests/CodeGen/TypeAnnotationTests.cs
+++ b/tests/Irooon.Tests/CodeGen/TypeAnnotationTests.cs
@@ -1,0 +1,252 @@
+using Xunit;
+using Irooon.Core.CodeGen;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Tests.CodeGen;
+
+/// <summary>
+/// 型アノテーション E2E テスト
+/// v0.12.2: 実行時型チェック
+/// </summary>
+public class TypeAnnotationTests
+{
+    private object? ExecuteScript(string source)
+    {
+        var tokens = new Core.Lexer.Lexer(source).ScanTokens();
+        var ast = new Core.Parser.Parser(tokens).Parse();
+        var resolver = new Core.Resolver.Resolver();
+        resolver.Resolve(ast);
+
+        var generator = new CodeGenerator();
+        var compiled = generator.Compile(ast);
+        var ctx = new ScriptContext();
+        return compiled(ctx);
+    }
+
+    #region パラメータ型チェック
+
+    [Fact]
+    public void TestTypeCheck_NumberParam_Pass()
+    {
+        var result = ExecuteScript(@"
+            fn add(a: Number, b: Number): Number { a + b }
+            add(1, 2)
+        ");
+        Assert.Equal(3.0, result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_NumberParam_Fail()
+    {
+        Assert.Throws<RuntimeException>(() => ExecuteScript(@"
+            fn add(a: Number, b: Number): Number { a + b }
+            add(""hello"", 2)
+        "));
+    }
+
+    [Fact]
+    public void TestTypeCheck_StringParam()
+    {
+        var result = ExecuteScript(@"
+            fn greet(name: String): String { ""Hello, "" + name }
+            greet(""World"")
+        ");
+        Assert.Equal("Hello, World", result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_BooleanParam()
+    {
+        var result = ExecuteScript(@"
+            fn check(flag: Boolean): Boolean { flag }
+            check(true)
+        ");
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_ListParam()
+    {
+        var result = ExecuteScript(@"
+            fn first(items: List): Number { items[0] }
+            first([10, 20, 30])
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_HashParam()
+    {
+        var result = ExecuteScript(@"
+            fn getName(data: Hash): String { data[""name""] }
+            getName({name: ""Alice""})
+        ");
+        Assert.Equal("Alice", result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_FunctionParam()
+    {
+        var result = ExecuteScript(@"
+            fn apply(f: Function, x: Number): Number { f(x) }
+            apply(fn (n) { n * 2 }, 5)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    #endregion
+
+    #region 戻り値型チェック
+
+    [Fact]
+    public void TestTypeCheck_ReturnType_Pass()
+    {
+        var result = ExecuteScript(@"
+            fn double(x: Number): Number { x * 2 }
+            double(5)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_ReturnType_Fail()
+    {
+        Assert.Throws<RuntimeException>(() => ExecuteScript(@"
+            fn bad(): Number { ""hello"" }
+            bad()
+        "));
+    }
+
+    #endregion
+
+    #region 部分的アノテーション・デフォルト値
+
+    [Fact]
+    public void TestTypeCheck_PartialAnnotation()
+    {
+        // data は型注釈なし、limit は Number 型
+        var result = ExecuteScript(@"
+            fn process(data, limit: Number) { data }
+            process(""anything"", 10)
+        ");
+        Assert.Equal("anything", result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_DefaultValue()
+    {
+        // デフォルト値を使用した場合も型チェックが通る
+        var result = ExecuteScript(@"
+            fn greet(name: String = ""World""): String { ""Hello, "" + name }
+            greet()
+        ");
+        Assert.Equal("Hello, World", result);
+    }
+
+    #endregion
+
+    #region ユーザー定義クラス
+
+    [Fact]
+    public void TestTypeCheck_UserDefinedClass()
+    {
+        var result = ExecuteScript(@"
+            class Person {
+                public var name = """"
+                init(n) { name = n }
+                public fn getName(): String { name }
+            }
+            fn greetPerson(p: Person): String { p.getName() }
+            let alice = Person(""Alice"")
+            greetPerson(alice)
+        ");
+        Assert.Equal("Alice", result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_UserDefinedClass_Fail()
+    {
+        Assert.Throws<RuntimeException>(() => ExecuteScript(@"
+            class Person {
+                public var name = """"
+            }
+            fn greetPerson(p: Person) { p }
+            greetPerson(""not a person"")
+        "));
+    }
+
+    #endregion
+
+    #region ラムダ・アロー関数
+
+    [Fact]
+    public void TestTypeCheck_Lambda()
+    {
+        var result = ExecuteScript(@"
+            let f = fn (x: Number): Number { x * 2 }
+            f(5)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public void TestTypeCheck_Arrow()
+    {
+        var result = ExecuteScript(@"
+            let g = (x: Number) => x * 2
+            g(5)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    #endregion
+
+    #region クラスメソッド
+
+    [Fact]
+    public void TestTypeCheck_Method()
+    {
+        var result = ExecuteScript(@"
+            class Calculator {
+                public fn add(a: Number, b: Number): Number { a + b }
+            }
+            let calc = Calculator()
+            calc.add(3, 4)
+        ");
+        Assert.Equal(7.0, result);
+    }
+
+    #endregion
+
+    #region return 文
+
+    [Fact]
+    public void TestTypeCheck_ReturnStmt()
+    {
+        // 明示的 return でも戻り値型チェック
+        var result = ExecuteScript(@"
+            fn double(x: Number): Number {
+                return x * 2
+            }
+            double(5)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    #endregion
+
+    #region 後方互換
+
+    [Fact]
+    public void TestTypeCheck_NoAnnotation()
+    {
+        // 型注釈なしの場合はチェックなし
+        var result = ExecuteScript(@"
+            fn add(a, b) { a + b }
+            add(1, 2)
+        ");
+        Assert.Equal(3.0, result);
+    }
+
+    #endregion
+}

--- a/tests/Irooon.Tests/Runtime/TypeCheckTests.cs
+++ b/tests/Irooon.Tests/Runtime/TypeCheckTests.cs
@@ -1,0 +1,78 @@
+using Irooon.Core.Runtime;
+using Xunit;
+using System.Collections.Generic;
+
+namespace Irooon.Tests.Runtime;
+
+/// <summary>
+/// RuntimeHelpers の型チェック機能テスト
+/// v0.12.2: 型アノテーション実装
+/// </summary>
+public class TypeCheckTests
+{
+    #region GetTypeName テスト
+
+    [Fact]
+    public void TestGetTypeName_AllTypes()
+    {
+        Assert.Equal("Null", RuntimeHelpers.GetTypeName(null));
+        Assert.Equal("Number", RuntimeHelpers.GetTypeName(42.0));
+        Assert.Equal("String", RuntimeHelpers.GetTypeName("hello"));
+        Assert.Equal("Boolean", RuntimeHelpers.GetTypeName(true));
+        Assert.Equal("List", RuntimeHelpers.GetTypeName(new List<object>()));
+        Assert.Equal("Hash", RuntimeHelpers.GetTypeName(new Dictionary<string, object>()));
+        Assert.Equal("Function", RuntimeHelpers.GetTypeName(
+            new BuiltinFunction("test", (ctx, args) => null!)));
+    }
+
+    #endregion
+
+    #region CheckType テスト
+
+    [Fact]
+    public void TestCheckType_Pass()
+    {
+        // 型が一致すればそのまま返る
+        var result = RuntimeHelpers.CheckType(42.0, "Number", "x", "test", 1, 1);
+        Assert.Equal(42.0, result);
+
+        var strResult = RuntimeHelpers.CheckType("hello", "String", "s", "test", 1, 1);
+        Assert.Equal("hello", strResult);
+    }
+
+    [Fact]
+    public void TestCheckType_Fail()
+    {
+        // 型不一致で RuntimeException
+        var ex = Assert.Throws<RuntimeException>(() =>
+            RuntimeHelpers.CheckType("hello", "Number", "x", "add", 1, 1));
+        Assert.Contains("Type error", ex.Message);
+        Assert.Contains("parameter 'x'", ex.Message);
+        Assert.Contains("expected Number", ex.Message);
+        Assert.Contains("got String", ex.Message);
+    }
+
+    #endregion
+
+    #region CheckReturnType テスト
+
+    [Fact]
+    public void TestCheckReturnType_Pass()
+    {
+        var result = RuntimeHelpers.CheckReturnType(42.0, "Number", "add", 1, 1);
+        Assert.Equal(42.0, result);
+    }
+
+    [Fact]
+    public void TestCheckReturnType_Fail()
+    {
+        var ex = Assert.Throws<RuntimeException>(() =>
+            RuntimeHelpers.CheckReturnType("hello", "Number", "add", 1, 1));
+        Assert.Contains("Type error", ex.Message);
+        Assert.Contains("function 'add'", ex.Message);
+        Assert.Contains("expected to return Number", ex.Message);
+        Assert.Contains("returned String", ex.Message);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- パラメータと戻り値に型注釈を追加し、実行時に型チェックを行う機能を実装
- サポート型: Number, String, Boolean, Null, List, Hash, Function + ユーザー定義クラス名
- 型不一致時に RuntimeException をスロー

## 変更内容
- **AST**: Parameter.TypeAnnotation, FunctionDef/LambdaExpr/MethodDef.ReturnType プロパティ追加
- **Parser**: 5つのメソッドに型アノテーション解析を追加
- **RuntimeHelpers**: GetTypeName(), CheckType(), CheckReturnType() 追加
- **CodeGenerator**: ExprTree に型チェックを埋め込み（Closure 変更不要）
- **テスト**: 31件追加（全1,149件合格）

Closes #49

## Test plan
- [x] Parser テスト 8件
- [x] CodeGen/E2E テスト 18件
- [x] RuntimeHelpers テスト 5件
- [x] 全回帰テスト 1,149件合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)