### PR TITLE
feat: v0.12.3 - パフォーマンスプロファイリング基盤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ publish/
 
 # Release builds
 /Release/
+
+# BenchmarkDotNet
+BenchmarkDotNet.Artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-02-11
+
+### Added
+- **パフォーマンスプロファイリング基盤** (#51)
+  - BenchmarkDotNet ベースのベンチマークプロジェクト (`benchmarks/Irooon.Benchmarks/`)
+  - マイクロベンチマーク: 算術演算、Invoke、Closure、Dictionary vs Array、Boxing
+  - マクロベンチマーク: tarai(10,5,0)、fibonacci(30)、ループ、算術スクリプト
+  - `[MemoryDiagnoser]` でアロケーション追跡
+
+### Performance Baseline (v0.12.3)
+
+| ベンチマーク | C# ネイティブ | irooon | 倍率 | アロケーション |
+|---|---|---|---|---|
+| tarai(10,5,0) | 364 μs | 121 ms | **334x** | 155 MB |
+| fibonacci(30) | 3.5 ms | 775 ms | **224x** | 1.37 GB |
+| loop(10K) | 9.1 μs | 153 ms | **16,950x** | 8.3 MB |
+| arithmetic(1K) | 5.9 μs | 143 ms | **24,428x** | 5.9 MB |
+
 ## [0.12.2] - 2026-02-10
 
 ### Added

--- a/Irooon.slnx
+++ b/Irooon.slnx
@@ -8,4 +8,7 @@
     <Project Path="tests/Irooon.Repl.Tests/Irooon.Repl.Tests.csproj" />
     <Project Path="tests/Irooon.Tests/Irooon.Tests.csproj" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Irooon.Benchmarks/Irooon.Benchmarks.csproj" />
+  </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -390,9 +390,22 @@ println("Abs:", abs, "Sqrt:", sqrt, "Now:", now)
 - [言語仕様](./docs/language-spec.md)
 - [ExpressionTree変換仕様](./docs/expression-tree-mapping.md)
 
+## ベンチマーク
+
+BenchmarkDotNet ベースのベンチマークスイートが含まれています。
+
+```bash
+# 全ベンチマーク実行
+dotnet run -c Release --project benchmarks/Irooon.Benchmarks
+
+# 特定カテゴリのみ
+dotnet run -c Release --project benchmarks/Irooon.Benchmarks -- --filter "*Tarai*"
+dotnet run -c Release --project benchmarks/Irooon.Benchmarks -- --filter "*Invoke*"
+```
+
 ## 開発状況
 
-現在のバージョン: **v0.12.2**
+現在のバージョン: **v0.12.3**
 
 変更履歴は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 

--- a/benchmarks/Irooon.Benchmarks/Helpers/BenchmarkHelper.cs
+++ b/benchmarks/Irooon.Benchmarks/Helpers/BenchmarkHelper.cs
@@ -1,0 +1,26 @@
+using Irooon.Core.CodeGen;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Benchmarks.Helpers;
+
+/// <summary>
+/// ベンチマーク用共通ユーティリティ。
+/// </summary>
+public static class BenchmarkHelper
+{
+    /// <summary>
+    /// スクリプトを事前コンパイルし、コンパイル済み関数とコンテキストを返す。
+    /// コンパイルコストを除外した純粋なランタイム計測に使用。
+    /// </summary>
+    public static (Func<ScriptContext, object?> compiled, ScriptContext ctx) PreCompile(string source)
+    {
+        var tokens = new Irooon.Core.Lexer.Lexer(source).ScanTokens();
+        var ast = new Irooon.Core.Parser.Parser(tokens).Parse();
+        var resolver = new Irooon.Core.Resolver.Resolver();
+        resolver.Resolve(ast);
+        var generator = new CodeGenerator();
+        var compiled = generator.Compile(ast);
+        var ctx = new ScriptContext();
+        return (compiled, ctx);
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Irooon.Benchmarks.csproj
+++ b/benchmarks/Irooon.Benchmarks/Irooon.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Irooon.Core\Irooon.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Irooon.Benchmarks/Macro/ArithmeticScriptBenchmark.cs
+++ b/benchmarks/Irooon.Benchmarks/Macro/ArithmeticScriptBenchmark.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using Irooon.Core;
+
+namespace Irooon.Benchmarks.Macro;
+
+/// <summary>
+/// 算術重視ベンチマーク。
+/// 複数の算術演算子 (*, +, -, /, %) のスループットを計測。
+/// </summary>
+[MemoryDiagnoser]
+public class ArithmeticScriptBenchmark
+{
+    private ScriptEngine _engine = null!;
+
+    private const string Script = @"
+        var result = 0
+        var i = 0
+        for (i < 1000) {
+            result = (i * 3 + i * 7 - i / 2) % 100
+            i = i + 1
+        }
+        result
+    ";
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new ScriptEngine();
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_ArithHeavy()
+    {
+        double result = 0;
+        for (int i = 0; i < 1000; i++)
+            result = (i * 3.0 + i * 7.0 - i / 2.0) % 100;
+        return result;
+    }
+
+    [Benchmark]
+    public object? Irooon_ArithHeavy()
+    {
+        return _engine.Execute(Script);
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Macro/FibonacciBenchmark.cs
+++ b/benchmarks/Irooon.Benchmarks/Macro/FibonacciBenchmark.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using Irooon.Core;
+
+namespace Irooon.Benchmarks.Macro;
+
+/// <summary>
+/// fibonacci(30) ベンチマーク — 中程度の再帰（約270万回）。
+/// </summary>
+[MemoryDiagnoser]
+public class FibonacciBenchmark
+{
+    private ScriptEngine _engine = null!;
+
+    private const string FibScript = @"
+        fn fib(n) {
+            if (n <= 1) { n }
+            else { fib(n - 1) + fib(n - 2) }
+        }
+        fib(30)
+    ";
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new ScriptEngine();
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_Fib30()
+    {
+        return Fib(30);
+    }
+
+    [Benchmark]
+    public object? Irooon_Fib30()
+    {
+        return _engine.Execute(FibScript);
+    }
+
+    private static double Fib(double n)
+    {
+        if (n <= 1) return n;
+        return Fib(n - 1) + Fib(n - 2);
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Macro/LoopBenchmark.cs
+++ b/benchmarks/Irooon.Benchmarks/Macro/LoopBenchmark.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using Irooon.Core;
+
+namespace Irooon.Benchmarks.Macro;
+
+/// <summary>
+/// ループ重視ベンチマーク（再帰なし）。
+/// 変数アクセス + 算術のみのオーバーヘッドを計測。
+/// </summary>
+[MemoryDiagnoser]
+public class LoopBenchmark
+{
+    private ScriptEngine _engine = null!;
+
+    private const string LoopScript = @"
+        var sum = 0
+        var i = 0
+        for (i < 10000) {
+            sum = sum + i
+            i = i + 1
+        }
+        sum
+    ";
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new ScriptEngine();
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_Loop10K()
+    {
+        double sum = 0;
+        for (int i = 0; i < 10000; i++)
+            sum += i;
+        return sum;
+    }
+
+    [Benchmark]
+    public object? Irooon_Loop10K()
+    {
+        return _engine.Execute(LoopScript);
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Macro/TaraiBenchmark.cs
+++ b/benchmarks/Irooon.Benchmarks/Macro/TaraiBenchmark.cs
@@ -1,0 +1,59 @@
+using BenchmarkDotNet.Attributes;
+using Irooon.Core;
+using Irooon.Core.Runtime;
+using Irooon.Benchmarks.Helpers;
+
+namespace Irooon.Benchmarks.Macro;
+
+/// <summary>
+/// tarai(10,5,0) ベンチマーク — 深い再帰。
+/// FullPipeline vs PreCompiled でコンパイルコスト vs ランタイムコストを分離。
+/// </summary>
+[MemoryDiagnoser]
+public class TaraiBenchmark
+{
+    private ScriptEngine _engine = null!;
+    private Func<ScriptContext, object?> _precompiled = null!;
+
+    private const string TaraiScript = @"
+        fn tarai(x, y, z) {
+            if (x <= y) { y }
+            else {
+                tarai(tarai(x - 1, y, z), tarai(y - 1, z, x), tarai(z - 1, x, y))
+            }
+        }
+        tarai(10, 5, 0)
+    ";
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new ScriptEngine();
+        (_precompiled, _) = BenchmarkHelper.PreCompile(TaraiScript);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_Tarai()
+    {
+        return Tarai(10.0, 5.0, 0.0);
+    }
+
+    [Benchmark]
+    public object? Irooon_Tarai_FullPipeline()
+    {
+        return _engine.Execute(TaraiScript);
+    }
+
+    [Benchmark]
+    public object? Irooon_Tarai_PreCompiled()
+    {
+        var ctx = new ScriptContext();
+        return _precompiled(ctx);
+    }
+
+    private static double Tarai(double x, double y, double z)
+    {
+        if (x <= y) return y;
+        return Tarai(Tarai(x - 1, y, z), Tarai(y - 1, z, x), Tarai(z - 1, x, y));
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Micro/ArithmeticBenchmarks.cs
+++ b/benchmarks/Irooon.Benchmarks/Micro/ArithmeticBenchmarks.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Benchmarks.Micro;
+
+/// <summary>
+/// 算術演算のオーバーヘッド計測。
+/// RuntimeHelpers.Add/Sub/Le vs ネイティブ C# 演算。
+/// </summary>
+[MemoryDiagnoser]
+public class ArithmeticBenchmarks
+{
+    private ScriptContext _ctx = null!;
+    private object _a = null!;
+    private object _b = null!;
+    private double _da;
+    private double _db;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _ctx = new ScriptContext();
+        _a = (object)10.0;
+        _b = (object)5.0;
+        _da = 10.0;
+        _db = 5.0;
+    }
+
+    // --- Baseline: ネイティブ C# ---
+
+    [Benchmark(Baseline = true)]
+    public double NativeAdd() => _da + _db;
+
+    [Benchmark]
+    public double NativeSub() => _da - _db;
+
+    [Benchmark]
+    public bool NativeLe() => _da <= _db;
+
+    // --- irooon RuntimeHelpers ---
+
+    [Benchmark]
+    public object IrooonAdd() => RuntimeHelpers.Add(_a, _b, _ctx);
+
+    [Benchmark]
+    public object IrooonSub() => RuntimeHelpers.Sub(_a, _b, _ctx);
+
+    [Benchmark]
+    public object IrooonLe() => RuntimeHelpers.Le(_a, _b, _ctx);
+
+    // --- 分解計測 ---
+
+    [Benchmark]
+    public object IrooonAdd_NoCtx() => RuntimeHelpers.Add(_a, _b);
+
+    [Benchmark]
+    public object BoxingRoundtrip()
+    {
+        double result = (double)_a + (double)_b;
+        return (object)result;
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Micro/BoxingBenchmarks.cs
+++ b/benchmarks/Irooon.Benchmarks/Micro/BoxingBenchmarks.cs
@@ -1,0 +1,39 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Irooon.Benchmarks.Micro;
+
+/// <summary>
+/// double→object ボクシングコスト分離計測。
+/// </summary>
+[MemoryDiagnoser]
+public class BoxingBenchmarks
+{
+    private object _boxedA = null!;
+    private object _boxedB = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _boxedA = (object)10.0;
+        _boxedB = (object)5.0;
+    }
+
+    [Benchmark(Baseline = true)]
+    public double NativeArithmetic()
+    {
+        double a = 10.0, b = 5.0;
+        return a - b;
+    }
+
+    [Benchmark]
+    public object BoxedArithmetic()
+    {
+        return (object)((double)_boxedA - (double)_boxedB);
+    }
+
+    [Benchmark]
+    public object ConvertToDoubleArithmetic()
+    {
+        return (object)(Convert.ToDouble(_boxedA) - Convert.ToDouble(_boxedB));
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Micro/ClosureBenchmarks.cs
+++ b/benchmarks/Irooon.Benchmarks/Micro/ClosureBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Benchmarks.Micro;
+
+/// <summary>
+/// CallStack.Push/Pop と配列パディングのコスト計測。
+/// </summary>
+[MemoryDiagnoser]
+public class ClosureBenchmarks
+{
+    private ScriptContext _ctx = null!;
+    private Closure _closure3Params = null!;
+    private object[] _fullArgs = null!;
+    private object[] _partialArgs = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _ctx = new ScriptContext();
+        Func<ScriptContext, object[], object> body = (ctx, args) => args[0];
+
+        _closure3Params = new Closure("test", body,
+            parameterNames: new List<string> { "x", "y", "z" });
+
+        _fullArgs = new object[] { 1.0, 2.0, 3.0 };
+        _partialArgs = new object[] { 1.0 };
+    }
+
+    [Benchmark(Baseline = true)]
+    public object InvokeFullArgs() => _closure3Params.Invoke(_ctx, _fullArgs);
+
+    [Benchmark]
+    public object InvokePartialArgs() => _closure3Params.Invoke(_ctx, _partialArgs);
+
+    [Benchmark]
+    public void CallStackPushPop()
+    {
+        CallStack.Push("test", 1, 1);
+        CallStack.Pop();
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Micro/DictionaryAccessBenchmarks.cs
+++ b/benchmarks/Irooon.Benchmarks/Micro/DictionaryAccessBenchmarks.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Irooon.Benchmarks.Micro;
+
+/// <summary>
+/// Dictionary&lt;string,object&gt; vs object[] アクセス速度比較。
+/// 配列ベーススコープ移行の根拠データ。
+/// </summary>
+[MemoryDiagnoser]
+public class DictionaryAccessBenchmarks
+{
+    private Dictionary<string, object> _globals = null!;
+    private object[] _array = null!;
+    private const int N = 1000;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _globals = new Dictionary<string, object>
+        {
+            ["x"] = 10.0, ["y"] = 5.0, ["z"] = 0.0,
+            ["a"] = 1.0, ["b"] = 2.0
+        };
+        _array = new object[] { 10.0, 5.0, 0.0, 1.0, 2.0 };
+    }
+
+    [Benchmark(Baseline = true)]
+    public object? DictionaryLookup()
+    {
+        object? result = null;
+        for (int i = 0; i < N; i++)
+        {
+            result = _globals["x"];
+            _globals["x"] = result!;
+        }
+        return result;
+    }
+
+    [Benchmark]
+    public object? DictionaryTryGetValue()
+    {
+        object? result = null;
+        for (int i = 0; i < N; i++)
+        {
+            _globals.TryGetValue("x", out result);
+            _globals["x"] = result!;
+        }
+        return result;
+    }
+
+    [Benchmark]
+    public object? ArrayAccess()
+    {
+        object? result = null;
+        for (int i = 0; i < N; i++)
+        {
+            result = _array[0];
+            _array[0] = result!;
+        }
+        return result;
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Micro/InvokeBenchmarks.cs
+++ b/benchmarks/Irooon.Benchmarks/Micro/InvokeBenchmarks.cs
@@ -1,0 +1,81 @@
+using BenchmarkDotNet.Attributes;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Benchmarks.Micro;
+
+/// <summary>
+/// RuntimeHelpers.Invoke() のパラメータ保存/復元オーバーヘッド計測。
+/// 最重要ベンチマーク: Dictionary 生成コストを定量化する。
+/// </summary>
+[MemoryDiagnoser]
+public class InvokeBenchmarks
+{
+    private ScriptContext _ctx = null!;
+    private Closure _simpleClosure = null!;
+    private Closure _paramsClosure = null!;
+    private Closure _paramsLocalsClosure = null!;
+    private Func<ScriptContext, object[], object> _rawBody = null!;
+    private object[] _args = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _ctx = new ScriptContext();
+        _args = new object[] { 10.0, 5.0, 0.0 };
+
+        // Identity 関数 — body は何もしない。純粋なオーバーヘッドを計測。
+        Func<ScriptContext, object[], object> identity = (ctx, args) => args[0];
+        _rawBody = identity;
+
+        _simpleClosure = new Closure("noop", identity);
+
+        _paramsClosure = new Closure("noop3", identity,
+            parameterNames: new List<string> { "x", "y", "z" });
+
+        _paramsLocalsClosure = new Closure("noop3loc", identity,
+            parameterNames: new List<string> { "x", "y", "z" },
+            localNames: new List<string> { "a", "b" });
+    }
+
+    [Benchmark(Baseline = true)]
+    public object DirectCall()
+    {
+        return _rawBody(_ctx, _args);
+    }
+
+    [Benchmark]
+    public object Invoke_NoClosure()
+    {
+        return RuntimeHelpers.Invoke(_simpleClosure, _ctx, _args);
+    }
+
+    [Benchmark]
+    public object Invoke_WithParams()
+    {
+        return RuntimeHelpers.Invoke(_paramsClosure, _ctx, _args);
+    }
+
+    [Benchmark]
+    public object Invoke_WithParamsAndLocals()
+    {
+        return RuntimeHelpers.Invoke(_paramsLocalsClosure, _ctx, _args);
+    }
+
+    [Benchmark]
+    public object ClosureInvoke_Direct()
+    {
+        // RuntimeHelpers.Invoke をバイパスし、Closure.Invoke 直接呼び出し
+        // （CallStack.Push/Pop のみのオーバーヘッド）
+        return _paramsClosure.Invoke(_ctx, _args);
+    }
+
+    [Benchmark]
+    public Dictionary<string, object> DictionaryAllocation()
+    {
+        var dict = new Dictionary<string, object>();
+        dict["x"] = 10.0;
+        dict["y"] = 5.0;
+        dict["z"] = 0.0;
+        return dict;
+    }
+}

--- a/benchmarks/Irooon.Benchmarks/Program.cs
+++ b/benchmarks/Irooon.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/tests/Irooon.Tests/Benchmarks/BenchmarkSanityTests.cs
+++ b/tests/Irooon.Tests/Benchmarks/BenchmarkSanityTests.cs
@@ -1,0 +1,86 @@
+using Xunit;
+using Irooon.Core;
+
+namespace Irooon.Tests.Benchmarks;
+
+/// <summary>
+/// ベンチマークスクリプトの正確性を確認するサニティテスト。
+/// v0.12.3: パフォーマンスプロファイリング基盤
+/// </summary>
+public class BenchmarkSanityTests
+{
+    private readonly ScriptEngine _engine = new();
+
+    #region Tarai
+
+    [Fact]
+    public void Tarai_CSharp_ReturnsCorrectResult()
+    {
+        static double Tarai(double x, double y, double z)
+        {
+            if (x <= y) return y;
+            return Tarai(Tarai(x - 1, y, z), Tarai(y - 1, z, x), Tarai(z - 1, x, y));
+        }
+
+        Assert.Equal(10.0, Tarai(10.0, 5.0, 0.0));
+    }
+
+    [Fact]
+    public void Tarai_Irooon_ReturnsCorrectResult()
+    {
+        var result = _engine.Execute(@"
+            fn tarai(x, y, z) {
+                if (x <= y) { y }
+                else {
+                    tarai(tarai(x - 1, y, z), tarai(y - 1, z, x), tarai(z - 1, x, y))
+                }
+            }
+            tarai(10, 5, 0)
+        ");
+        Assert.Equal(10.0, result);
+    }
+
+    #endregion
+
+    #region Fibonacci
+
+    [Fact]
+    public void Fibonacci_BothMatch()
+    {
+        static double Fib(double n)
+        {
+            if (n <= 1) return n;
+            return Fib(n - 1) + Fib(n - 2);
+        }
+
+        var iroResult = _engine.Execute(@"
+            fn fib(n) {
+                if (n <= 1) { n }
+                else { fib(n - 1) + fib(n - 2) }
+            }
+            fib(20)
+        ");
+        Assert.Equal(Fib(20), (double)iroResult!);
+    }
+
+    #endregion
+
+    #region Loop
+
+    [Fact]
+    public void Loop_ReturnsCorrectResult()
+    {
+        var result = _engine.Execute(@"
+            var sum = 0
+            var i = 0
+            for (i < 100) {
+                sum = sum + i
+                i = i + 1
+            }
+            sum
+        ");
+        Assert.Equal(4950.0, result);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- BenchmarkDotNet ベースのベンチマークプロジェクト追加 (`benchmarks/Irooon.Benchmarks/`)
- マイクロベンチマーク5種: Arithmetic, Invoke, Closure, DictionaryAccess, Boxing
- マクロベンチマーク4種: Tarai, Fibonacci, Loop, ArithmeticScript
- サニティテスト4件追加

### ベースライン結果

#### マクロベンチマーク（C# ネイティブ比）

| ベンチマーク | C# | irooon | 倍率 | Allocated |
|---|---|---|---|---|
| tarai(10,5,0) PreCompiled | 364 μs | 121 ms | **334x** | 155 MB |
| tarai(10,5,0) FullPipeline | 364 μs | 289 ms | **795x** | 160 MB |
| fibonacci(30) | 3.5 ms | 775 ms | **224x** | 1.37 GB |
| loop(10K) | 9.1 μs | 153 ms | **16,950x** | 8.3 MB |
| arithmetic(1K) | 5.9 μs | 143 ms | **24,428x** | 5.9 MB |

#### マイクロベンチマーク

| 項目 | 結果 |
|---|---|
| RuntimeHelpers.Invoke (3 params) | 154 ns/call (**94x** vs direct) → 152 B allocated |
| Invoke (3 params + 2 locals) | 210 ns/call (**128x**) → 232 B allocated |
| Closure.Invoke (CallStack only) | 25 ns/call (**15x**) → 32 B allocated |
| Dictionary allocation (3 entries) | 87 ns → 288 B |
| Dictionary vs Array access | Dictionary **3.5x slower** than array |
| IrooonAdd (with ctx) | 13 ns → 56 B (**magic method lookup 有**) |
| IrooonAdd (no ctx) | 7.4 ns → 24 B (boxing のみ) |
| Boxing roundtrip | 7.5 ns → 24 B |

Closes #51

## Test plan
- [x] 全 1,153 テスト合格 (1,141 + 12)
- [x] サニティテスト 4/4 合格
- [x] ベンチマーク全 32 メソッド実行完了
- [x] BenchmarkDotNet.Artifacts/ を .gitignore に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)