### PR TITLE
feat: v0.12.5 - Double Fast Path + Boolean Caching + CallFrame struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-02-11
+
+### Changed
+- **パフォーマンス最適化 #2: Double Fast Path + Boolean Caching + CallFrame struct 化** (#55)
+  - RuntimeHelpers: 算術演算（Add/Sub/Mul/Div/Mod/Power）に `if (a is double)` fast path を追加
+  - RuntimeHelpers: 比較演算（Lt/Le/Gt/Ge/Eq/Ne）に double fast path + `BoxedTrue`/`BoxedFalse` キャッシュ
+  - RuntimeHelpers: 単項演算（Increment/Decrement/Negate）に double fast path
+  - RuntimeHelpers: `Not` メソッドに `BoxedTrue`/`BoxedFalse` 適用
+  - CallFrame: `class` → `readonly record struct` に変更（関数呼び出しのヒープアロケーション削減）
+
+### Performance (v0.12.5 vs v0.12.4)
+
+| ベンチマーク | v0.12.4 | v0.12.5 | 改善 | メモリ削減 |
+|---|---|---|---|---|
+| tarai(10,5,0) PreCompiled | 48 ms (97 MB) | 63 ms (56 MB) | メモリ **42% 削減** | 97 MB → 56 MB |
+| fibonacci(30) | 645 ms (878 MB) | 410 ms (511 MB) | **1.57x 高速化** | 878 MB → 511 MB |
+| loop(10K) | 158 ms (8.3 MB) | 91 ms (5.8 MB) | **1.74x 高速化** | 8.3 MB → 5.8 MB |
+
+- fibonacci: Convert.ToDouble() 回避 + bool boxing 削減で大幅改善
+- loop: トップレベルの算術/比較が fast path に乗り大幅改善
+- tarai: タイミング分散大だがメモリアロケーション42%削減
+
 ## [0.12.4] - 2026-02-11
 
 ### Changed

--- a/src/Irooon.Core/Runtime/CallStack.cs
+++ b/src/Irooon.Core/Runtime/CallStack.cs
@@ -65,34 +65,6 @@ public static class CallStack
 
 /// <summary>
 /// 関数呼び出しの情報を保持します。
+/// 値型（struct）としてスタックに直接格納され、ヒープアロケーションを回避します。
 /// </summary>
-public class CallFrame
-{
-    /// <summary>
-    /// 関数名
-    /// </summary>
-    public string FunctionName { get; }
-
-    /// <summary>
-    /// 行番号
-    /// </summary>
-    public int Line { get; }
-
-    /// <summary>
-    /// 列番号
-    /// </summary>
-    public int Column { get; }
-
-    /// <summary>
-    /// CallFrameの新しいインスタンスを初期化します。
-    /// </summary>
-    /// <param name="functionName">関数名</param>
-    /// <param name="line">行番号</param>
-    /// <param name="column">列番号</param>
-    public CallFrame(string functionName, int line, int column)
-    {
-        FunctionName = functionName;
-        Line = line;
-        Column = column;
-    }
-}
+public readonly record struct CallFrame(string FunctionName, int Line, int Column);

--- a/tests/Irooon.Tests/Optimization/FastPathTests.cs
+++ b/tests/Irooon.Tests/Optimization/FastPathTests.cs
@@ -1,0 +1,220 @@
+using Irooon.Core.Runtime;
+
+namespace Irooon.Tests.Optimization;
+
+/// <summary>
+/// v0.12.5 パフォーマンス最適化テスト
+/// - Double Fast Path（算術・比較・インクリメント）
+/// - Boolean キャッシング（BoxedTrue/BoxedFalse）
+/// - CallFrame struct 化
+/// </summary>
+public class FastPathTests
+{
+    #region Double Fast Path - Arithmetic
+
+    [Fact]
+    public void Add_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Add(3.0, 5.0);
+        Assert.Equal(8.0, result);
+    }
+
+    [Fact]
+    public void Sub_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Sub(10.0, 3.0);
+        Assert.Equal(7.0, result);
+    }
+
+    [Fact]
+    public void Mul_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Mul(4.0, 5.0);
+        Assert.Equal(20.0, result);
+    }
+
+    [Fact]
+    public void Div_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Div(15.0, 3.0);
+        Assert.Equal(5.0, result);
+    }
+
+    [Fact]
+    public void Div_DoubleFastPath_DivByZero()
+    {
+        Assert.Throws<DivideByZeroException>(() => RuntimeHelpers.Div(1.0, 0.0));
+    }
+
+    [Fact]
+    public void Mod_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Mod(10.0, 3.0);
+        Assert.Equal(1.0, result);
+    }
+
+    [Fact]
+    public void Power_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Power(2.0, 10.0);
+        Assert.Equal(1024.0, result);
+    }
+
+    #endregion
+
+    #region Double Fast Path - Comparison
+
+    [Fact]
+    public void Lt_DoubleFastPath_True()
+    {
+        var result = RuntimeHelpers.Lt(3.0, 5.0);
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void Lt_DoubleFastPath_False()
+    {
+        var result = RuntimeHelpers.Lt(5.0, 3.0);
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void Le_DoubleFastPath_Equal()
+    {
+        Assert.Equal(true, RuntimeHelpers.Le(5.0, 5.0));
+        Assert.Equal(true, RuntimeHelpers.Le(3.0, 5.0));
+        Assert.Equal(false, RuntimeHelpers.Le(5.0, 3.0));
+    }
+
+    [Fact]
+    public void Gt_DoubleFastPath()
+    {
+        Assert.Equal(true, RuntimeHelpers.Gt(5.0, 3.0));
+        Assert.Equal(false, RuntimeHelpers.Gt(3.0, 5.0));
+    }
+
+    [Fact]
+    public void Ge_DoubleFastPath()
+    {
+        Assert.Equal(true, RuntimeHelpers.Ge(5.0, 5.0));
+        Assert.Equal(true, RuntimeHelpers.Ge(5.0, 3.0));
+        Assert.Equal(false, RuntimeHelpers.Ge(3.0, 5.0));
+    }
+
+    [Fact]
+    public void Eq_DoubleFastPath()
+    {
+        Assert.Equal(true, RuntimeHelpers.Eq(5.0, 5.0));
+        Assert.Equal(false, RuntimeHelpers.Eq(3.0, 5.0));
+    }
+
+    [Fact]
+    public void Ne_DoubleFastPath()
+    {
+        Assert.Equal(true, RuntimeHelpers.Ne(3.0, 5.0));
+        Assert.Equal(false, RuntimeHelpers.Ne(5.0, 5.0));
+    }
+
+    #endregion
+
+    #region Double Fast Path - Unary
+
+    [Fact]
+    public void Increment_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Increment(5.0);
+        Assert.Equal(6.0, result);
+    }
+
+    [Fact]
+    public void Decrement_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Decrement(5.0);
+        Assert.Equal(4.0, result);
+    }
+
+    [Fact]
+    public void Negate_DoubleFastPath()
+    {
+        var result = RuntimeHelpers.Negate(5.0);
+        Assert.Equal(-5.0, result);
+    }
+
+    #endregion
+
+    #region Boolean Caching
+
+    [Fact]
+    public void BoolCaching_Lt_ReturnsCachedTrue()
+    {
+        var result = RuntimeHelpers.Lt(3.0, 5.0);
+        Assert.Same(RuntimeHelpers.BoxedTrue, result);
+    }
+
+    [Fact]
+    public void BoolCaching_Lt_ReturnsCachedFalse()
+    {
+        var result = RuntimeHelpers.Lt(5.0, 3.0);
+        Assert.Same(RuntimeHelpers.BoxedFalse, result);
+    }
+
+    [Fact]
+    public void BoolCaching_Eq_ReturnsCachedTrue()
+    {
+        var result = RuntimeHelpers.Eq(5.0, 5.0);
+        Assert.Same(RuntimeHelpers.BoxedTrue, result);
+    }
+
+    [Fact]
+    public void BoolCaching_Not_ReturnsCachedBool()
+    {
+        Assert.Same(RuntimeHelpers.BoxedTrue, RuntimeHelpers.Not(null));
+        Assert.Same(RuntimeHelpers.BoxedFalse, RuntimeHelpers.Not(true));
+    }
+
+    #endregion
+
+    #region CallFrame struct
+
+    [Fact]
+    public void CallFrame_IsValueType()
+    {
+        Assert.True(typeof(CallFrame).IsValueType);
+    }
+
+    [Fact]
+    public void CallFrame_PreservesData()
+    {
+        var frame = new CallFrame("test", 10, 5);
+        Assert.Equal("test", frame.FunctionName);
+        Assert.Equal(10, frame.Line);
+        Assert.Equal(5, frame.Column);
+    }
+
+    #endregion
+
+    #region Fallback - Existing behavior preserved
+
+    [Fact]
+    public void Add_StringConcat_StillWorks()
+    {
+        Assert.Equal("ab", RuntimeHelpers.Add("a", "b"));
+        Assert.Equal("3hello", RuntimeHelpers.Add(3.0, "hello"));
+    }
+
+    [Fact]
+    public void Eq_NullHandling_StillWorks()
+    {
+        Assert.Equal(true, RuntimeHelpers.Eq(null!, null!));
+        Assert.Equal(false, RuntimeHelpers.Eq(null!, 5.0));
+        Assert.Equal(false, RuntimeHelpers.Eq(5.0, null!));
+    }
+
+    [Fact]
+    public void Lt_NullThrows_StillWorks()
+    {
+        Assert.Throws<InvalidOperationException>(() => RuntimeHelpers.Lt(null!, 5.0));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- 算術/比較/インクリメント演算に `if (a is double)` fast path を追加し `Convert.ToDouble()` を回避
- 比較演算に `BoxedTrue`/`BoxedFalse` キャッシュで bool→object boxing を削減
- `CallFrame` を class → `readonly record struct` に変更しヒープアロケーション削減

### パフォーマンス改善

| ベンチマーク | v0.12.4 | v0.12.5 | 改善 | メモリ |
|---|---|---|---|---|
| fibonacci(30) | 645ms (878MB) | 410ms (511MB) | **1.57x** | **42%減** |
| loop(10K) | 158ms (8.3MB) | 91ms (5.8MB) | **1.74x** | 30%減 |
| tarai(10,5,0) | 48ms (97MB) | 63ms (56MB) | メモリ **42%減** | — |

Closes #55

## Test plan

- [x] 全 1,197 テスト合格（既存 1,171 + 新規 26）
- [x] BenchmarkDotNet で性能比較実施
- [x] 既存の文字列連結/null処理/マジックメソッドの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)