### PR TITLE
feat: v0.13.1 - HTTP クライアント (fetch / http)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-02-12
+
+### Added - HTTP クライアント (#63)
+
+- **`fetch(url, options?)`** — 汎用 HTTP リクエスト関数
+  - `options`: `{ method, headers, body, timeout }` で詳細設定
+  - 戻り値: `Task<Hash>` — await で `{ status, body, headers, ok }` を取得
+- **`http` オブジェクト** — 便利メソッド
+  - `http.get(url, headers?)` — GET リクエスト
+  - `http.post(url, body?, headers?)` — POST リクエスト
+  - `http.put(url, body?, headers?)` — PUT リクエスト
+  - `http.delete(url, headers?)` — DELETE リクエスト
+  - `http.patch(url, body?, headers?)` — PATCH リクエスト
+- C# プリミティブ `__httpRequest` (HttpClient ベース、async/await 対応)
+- テスト用 `RuntimeHelpers.SetHttpClient()` / `ResetHttpClient()` (InternalsVisibleTo)
+
+### Fixed
+
+- Hash の GetMember でキーアクセスがプロトタイプメソッドより優先されるように修正
+  - `hash["delete"] = fn(...)` のようにキーに関数を格納した場合、Hash プロトタイプの `delete` メソッドではなくキーの値が返される
+
 ## [0.13.0] - 2026-02-11
 
 ### Added

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -848,6 +848,40 @@ async fn compute(x) { x * 2 }
 let results = awaitAll([compute(1), compute(2), compute(3)])  // [2, 4, 6]
 ```
 
+### fetch / http — HTTP クライアント
+
+```iro
+// fetch(url, options?) — 汎用 HTTP リクエスト
+// 戻り値: Task<Hash> — await で { status, body, headers, ok } を取得
+async fn main() {
+    let res = await fetch("https://api.example.com/data")
+    println(res.status)   // 200
+    println(res.body)     // レスポンスボディ
+    println(res.ok)       // true
+
+    // POST リクエスト（オプション指定）
+    let res = await fetch("https://api.example.com/users", {
+        method: "POST",
+        body: jsonStringify({ name: "Alice" }),
+        headers: { "Content-Type": "application/json" },
+        timeout: 5000
+    })
+}
+```
+
+```iro
+// http オブジェクト — 便利メソッド
+async fn main() {
+    let res = await http.get("https://api.example.com/users")
+    let users = jsonParse(res.body)
+
+    let res = await http.post(url, body, headers)
+    let res = await http.put(url, body, headers)
+    let res = await http.delete(url, headers)
+    let res = await http.patch(url, body, headers)
+}
+```
+
 ---
 
 ## 16. CLR 相互運用

--- a/examples/http_example.iro
+++ b/examples/http_example.iro
@@ -1,0 +1,41 @@
+// HTTP クライアントのサンプル
+// 注意: async fn 内で await を使用する必要があります
+
+// シンプルな GET リクエスト
+async fn fetchExample() {
+    let res = await fetch("https://httpbin.org/get")
+    println("Status:", res.status)
+    println("OK:", res.ok)
+    println("Body:", res.body)
+}
+
+// POST リクエスト（JSON）
+async fn postExample() {
+    let headers = { "Content-Type": "application/json" }
+    let body = jsonStringify({ name: "Alice", age: 30 })
+    let res = await http.post("https://httpbin.org/post", body, headers)
+    println("POST Status:", res.status)
+    let data = jsonParse(res.body)
+    println("Response:", data)
+}
+
+// カスタムヘッダ付き GET
+async fn authExample() {
+    let headers = {
+        "Authorization": "Bearer my-token",
+        "Accept": "application/json"
+    }
+    let res = await http.get("https://httpbin.org/headers", headers)
+    println("Auth Status:", res.status)
+}
+
+// エラーハンドリング
+async fn errorExample() {
+    let res = await fetch("https://httpbin.org/status/404")
+    if (not res.ok) {
+        println("Error:", res.status)
+    }
+}
+
+// 実行
+let t = fetchExample()

--- a/src/Irooon.Core/Irooon.Core.csproj
+++ b/src/Irooon.Core/Irooon.Core.csproj
@@ -10,4 +10,8 @@
     <EmbeddedResource Include="stdlib.iro" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Irooon.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Irooon.Core/Runtime/ScriptContext.cs
+++ b/src/Irooon.Core/Runtime/ScriptContext.cs
@@ -166,5 +166,8 @@ public class ScriptContext
         Globals["__mathRandom"] = new BuiltinFunction("__mathRandom", RuntimeHelpers.__mathRandom);
 
         Globals["__registerPrototype"] = new BuiltinFunction("__registerPrototype", RuntimeHelpers.__registerPrototype);
+
+        // HTTP プリミティブ
+        Globals["__httpRequest"] = new BuiltinFunction("__httpRequest", RuntimeHelpers.__httpRequest);
     }
 }

--- a/src/Irooon.Core/stdlib.iro
+++ b/src/Irooon.Core/stdlib.iro
@@ -621,3 +621,91 @@ fn jsonParse(input) {
     skipWS()
     result
 }
+
+// ========================================
+// HTTP CLIENT
+// ========================================
+
+// fetch(url, options?) — 汎用 HTTP リクエスト関数
+// options: { method, headers, body, timeout }
+// 戻り値: Task<Hash> — await で { status, body, headers, ok } を取得
+fn fetch(url, options) {
+    var method = "GET"
+    var headers = null
+    var body = null
+    var timeout = null
+
+    if (options != null) {
+        if (__hashHas(options, "method")) {
+            method = options["method"]
+        }
+        if (__hashHas(options, "headers")) {
+            headers = options["headers"]
+        }
+        if (__hashHas(options, "body")) {
+            body = options["body"]
+        }
+        if (__hashHas(options, "timeout")) {
+            timeout = options["timeout"]
+        }
+    }
+
+    __httpRequest(method, url, headers, body, timeout)
+}
+
+// http オブジェクト — 便利メソッド
+var http = __hashNew()
+
+http["get"] = fn(url, headers) {
+    var opts = __hashNew()
+    opts["method"] = "GET"
+    if (headers != null) {
+        opts["headers"] = headers
+    }
+    fetch(url, opts)
+}
+
+http["post"] = fn(url, body, headers) {
+    var opts = __hashNew()
+    opts["method"] = "POST"
+    if (body != null) {
+        opts["body"] = body
+    }
+    if (headers != null) {
+        opts["headers"] = headers
+    }
+    fetch(url, opts)
+}
+
+http["put"] = fn(url, body, headers) {
+    var opts = __hashNew()
+    opts["method"] = "PUT"
+    if (body != null) {
+        opts["body"] = body
+    }
+    if (headers != null) {
+        opts["headers"] = headers
+    }
+    fetch(url, opts)
+}
+
+http["delete"] = fn(url, headers) {
+    var opts = __hashNew()
+    opts["method"] = "DELETE"
+    if (headers != null) {
+        opts["headers"] = headers
+    }
+    fetch(url, opts)
+}
+
+http["patch"] = fn(url, body, headers) {
+    var opts = __hashNew()
+    opts["method"] = "PATCH"
+    if (body != null) {
+        opts["body"] = body
+    }
+    if (headers != null) {
+        opts["headers"] = headers
+    }
+    fetch(url, opts)
+}

--- a/tests/Irooon.Tests/Integration/HttpClientE2ETests.cs
+++ b/tests/Irooon.Tests/Integration/HttpClientE2ETests.cs
@@ -1,0 +1,258 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Irooon.Core;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Tests.Integration;
+
+/// <summary>
+/// HTTP クライアントの E2E テスト。
+/// ScriptEngine 経由で fetch / http オブジェクトの動作を検証する。
+/// MockHttpMessageHandler を使用し、実際のネットワーク通信は行わない。
+/// await はトップレベルで使えないため async fn でラップし、Task として実行する。
+/// </summary>
+[Collection("HttpClient")]
+public class HttpClientE2ETests : IDisposable
+{
+    private readonly ScriptEngine _engine = new();
+
+    private void SetupMock(HttpStatusCode statusCode = HttpStatusCode.OK, string content = "",
+        Dictionary<string, string>? responseHeaders = null)
+    {
+        var handler = new MockHttpMessageHandler(statusCode, content, responseHeaders);
+        RuntimeHelpers.SetHttpClient(new HttpClient(handler));
+    }
+
+    public void Dispose()
+    {
+        RuntimeHelpers.ResetHttpClient();
+    }
+
+    /// <summary>async fn でラップしたスクリプトを実行し、Task の結果を返す</summary>
+    private object? ExecuteAsync(string asyncBody)
+    {
+        var script = $@"
+            async fn __test__() {{
+                {asyncBody}
+            }}
+            __test__()
+        ";
+        var task = (Task<object>)_engine.Execute(script)!;
+        return task.GetAwaiter().GetResult();
+    }
+
+    #region fetch 基本テスト
+
+    [Fact]
+    public void Fetch_Get_ReturnsStatus()
+    {
+        SetupMock(HttpStatusCode.OK, "hello");
+        var result = ExecuteAsync(@"
+            let res = await fetch(""http://test.example.com/api"")
+            res[""status""]
+        ");
+        Assert.Equal(200.0, result);
+    }
+
+    [Fact]
+    public void Fetch_Get_ReturnsBody()
+    {
+        SetupMock(HttpStatusCode.OK, "response body");
+        var result = ExecuteAsync(@"
+            let res = await fetch(""http://test.example.com/api"")
+            res[""body""]
+        ");
+        Assert.Equal("response body", result);
+    }
+
+    [Fact]
+    public void Fetch_Get_ReturnsOk()
+    {
+        SetupMock(HttpStatusCode.OK);
+        var result = ExecuteAsync(@"
+            let res = await fetch(""http://test.example.com/api"")
+            res[""ok""]
+        ");
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void Fetch_Post_WithOptions()
+    {
+        SetupMock(HttpStatusCode.Created, "{\"id\":1}");
+        var result = ExecuteAsync(@"
+            let opts = {
+                method: ""POST"",
+                body: ""{ }"",
+                headers: { ""Content-Type"": ""application/json"" }
+            }
+            let res = await fetch(""http://test.example.com/users"", opts)
+            res[""status""]
+        ");
+        Assert.Equal(201.0, result);
+    }
+
+    [Fact]
+    public void Fetch_NotFound_OkIsFalse()
+    {
+        SetupMock(HttpStatusCode.NotFound);
+        var result = ExecuteAsync(@"
+            let res = await fetch(""http://test.example.com/missing"")
+            res[""ok""]
+        ");
+        Assert.Equal(false, result);
+    }
+
+    #endregion
+
+    #region http オブジェクト
+
+    [Fact]
+    public void Http_Get_Works()
+    {
+        SetupMock(HttpStatusCode.OK, "get result");
+        var result = ExecuteAsync(@"
+            let res = await http.get(""http://test.example.com/api"")
+            res[""body""]
+        ");
+        Assert.Equal("get result", result);
+    }
+
+    [Fact]
+    public void Http_Post_Works()
+    {
+        SetupMock(HttpStatusCode.Created, "created");
+        var result = ExecuteAsync(@"
+            let headers = { ""Content-Type"": ""application/json"" }
+            let res = await http.post(""http://test.example.com/api"", ""body data"", headers)
+            res[""status""]
+        ");
+        Assert.Equal(201.0, result);
+    }
+
+    [Fact]
+    public void Http_Put_Works()
+    {
+        SetupMock(HttpStatusCode.OK, "updated");
+        var result = ExecuteAsync(@"
+            let res = await http.put(""http://test.example.com/item/1"", ""new data"", null)
+            res[""body""]
+        ");
+        Assert.Equal("updated", result);
+    }
+
+    [Fact]
+    public void Http_Delete_Works()
+    {
+        SetupMock(HttpStatusCode.NoContent, "");
+        var result = ExecuteAsync(@"
+            let res = await http.delete(""http://test.example.com/item/1"")
+            res[""status""]
+        ");
+        Assert.Equal(204.0, result);
+    }
+
+    [Fact]
+    public void Http_Patch_Works()
+    {
+        SetupMock(HttpStatusCode.OK, "patched");
+        var result = ExecuteAsync(@"
+            let res = await http.patch(""http://test.example.com/item/1"", ""patch data"", null)
+            res[""body""]
+        ");
+        Assert.Equal("patched", result);
+    }
+
+    #endregion
+
+    #region JSON 統合
+
+    [Fact]
+    public void Fetch_JsonParse_Integration()
+    {
+        SetupMock(HttpStatusCode.OK, "{\"name\":\"Alice\",\"age\":30}");
+        var result = ExecuteAsync(@"
+            let res = await fetch(""http://test.example.com/user"")
+            let data = jsonParse(res[""body""])
+            data[""name""]
+        ");
+        Assert.Equal("Alice", result);
+    }
+
+    [Fact]
+    public void Http_Post_JsonStringify_Integration()
+    {
+        SetupMock(HttpStatusCode.Created, "{\"id\":42}");
+        var result = ExecuteAsync(@"
+            let headers = { ""Content-Type"": ""application/json"" }
+            let body = jsonStringify({ name: ""Bob"" })
+            let res = await http.post(""http://test.example.com/users"", body, headers)
+            let data = jsonParse(res[""body""])
+            data[""id""]
+        ");
+        Assert.Equal(42.0, result);
+    }
+
+    #endregion
+
+    #region エラーハンドリング
+
+    [Fact]
+    public void Fetch_InvalidUrl_ThrowsScriptException()
+    {
+        // URL が空文字列の場合、RuntimeException が ScriptException として伝播する
+        SetupMock(HttpStatusCode.OK);
+        var ex = Assert.Throws<ScriptException>(() => _engine.Execute(@"fetch("""")"));
+        Assert.Contains("URL is required", ex.Message);
+    }
+
+    [Fact]
+    public void Http_Get_WithHeaders()
+    {
+        SetupMock(HttpStatusCode.OK, "authenticated");
+        var result = ExecuteAsync(@"
+            let headers = { ""Authorization"": ""Bearer token123"" }
+            let res = await http.get(""http://test.example.com/me"", headers)
+            res[""body""]
+        ");
+        Assert.Equal("authenticated", result);
+    }
+
+    #endregion
+
+    #region MockHttpMessageHandler
+
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _content;
+        private readonly Dictionary<string, string>? _responseHeaders;
+
+        public MockHttpMessageHandler(HttpStatusCode statusCode = HttpStatusCode.OK,
+            string content = "", Dictionary<string, string>? responseHeaders = null)
+        {
+            _statusCode = statusCode;
+            _content = content;
+            _responseHeaders = responseHeaders;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_content)
+            };
+            if (_responseHeaders != null)
+            {
+                foreach (var h in _responseHeaders)
+                    response.Headers.TryAddWithoutValidation(h.Key, h.Value);
+            }
+            return Task.FromResult(response);
+        }
+    }
+
+    #endregion
+}

--- a/tests/Irooon.Tests/Runtime/HttpClientTests.cs
+++ b/tests/Irooon.Tests/Runtime/HttpClientTests.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using Xunit;
+using Irooon.Core.Runtime;
+
+namespace Irooon.Tests.Runtime;
+
+/// <summary>
+/// HTTP クライアントプリミティブ (__httpRequest) の単体テスト。
+/// MockHttpMessageHandler を使用し、実際のネットワーク通信は行わない。
+/// </summary>
+[Collection("HttpClient")]
+public class HttpClientTests : IDisposable
+{
+    private MockHttpMessageHandler _handler = null!;
+
+    private void SetupMock(HttpStatusCode statusCode = HttpStatusCode.OK, string content = "",
+        Dictionary<string, string>? responseHeaders = null)
+    {
+        _handler = new MockHttpMessageHandler(statusCode, content, responseHeaders);
+        RuntimeHelpers.SetHttpClient(new HttpClient(_handler));
+    }
+
+    public void Dispose()
+    {
+        RuntimeHelpers.ResetHttpClient();
+    }
+
+    #region GET リクエスト
+
+    [Fact]
+    public async Task HttpRequest_Get_ReturnsResponse()
+    {
+        SetupMock(HttpStatusCode.OK, "Hello World");
+
+        var ctx = new ScriptContext();
+        var result = RuntimeHelpers.__httpRequest(ctx, new object[] { "GET", "http://test.example.com/api", null!, null!, null! });
+
+        Assert.IsAssignableFrom<Task<object>>(result);
+        var response = await (Task<object>)result;
+        var hash = Assert.IsType<Dictionary<string, object>>(response);
+        Assert.Equal(200.0, hash["status"]);
+        Assert.Equal("Hello World", hash["body"]);
+        Assert.Equal(true, hash["ok"]);
+    }
+
+    [Fact]
+    public async Task HttpRequest_Get_SendsCorrectMethod()
+    {
+        SetupMock();
+
+        var ctx = new ScriptContext();
+        await (Task<object>)RuntimeHelpers.__httpRequest(ctx, new object[] { "GET", "http://test.example.com/api", null!, null!, null! });
+
+        Assert.Equal(HttpMethod.Get, _handler.LastRequest!.Method);
+        Assert.Equal("http://test.example.com/api", _handler.LastRequest.RequestUri!.ToString());
+    }
+
+    #endregion
+
+    #region POST リクエスト
+
+    [Fact]
+    public async Task HttpRequest_Post_SendsBody()
+    {
+        SetupMock(HttpStatusCode.Created, "{\"id\":1}");
+
+        var ctx = new ScriptContext();
+        var headers = new Dictionary<string, object> { ["Content-Type"] = "application/json" };
+        var result = await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "POST", "http://test.example.com/users", headers, "{\"name\":\"Alice\"}", null! });
+
+        var hash = Assert.IsType<Dictionary<string, object>>(result);
+        Assert.Equal(201.0, hash["status"]);
+
+        var requestBody = await _handler.LastRequest!.Content!.ReadAsStringAsync();
+        Assert.Equal("{\"name\":\"Alice\"}", requestBody);
+        Assert.Equal(HttpMethod.Post, _handler.LastRequest.Method);
+    }
+
+    #endregion
+
+    #region PUT / DELETE / PATCH
+
+    [Fact]
+    public async Task HttpRequest_Put_Method()
+    {
+        SetupMock();
+        var ctx = new ScriptContext();
+        await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "PUT", "http://test.example.com/item/1", null!, "updated", null! });
+        Assert.Equal(HttpMethod.Put, _handler.LastRequest!.Method);
+    }
+
+    [Fact]
+    public async Task HttpRequest_Delete_Method()
+    {
+        SetupMock();
+        var ctx = new ScriptContext();
+        await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "DELETE", "http://test.example.com/item/1", null!, null!, null! });
+        Assert.Equal(HttpMethod.Delete, _handler.LastRequest!.Method);
+    }
+
+    [Fact]
+    public async Task HttpRequest_Patch_Method()
+    {
+        SetupMock();
+        var ctx = new ScriptContext();
+        await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "PATCH", "http://test.example.com/item/1", null!, "patched", null! });
+        Assert.Equal(HttpMethod.Patch, _handler.LastRequest!.Method);
+    }
+
+    #endregion
+
+    #region レスポンス構造
+
+    [Fact]
+    public async Task HttpRequest_Response_HasCorrectStructure()
+    {
+        SetupMock(HttpStatusCode.OK, "body content");
+
+        var ctx = new ScriptContext();
+        var result = await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "GET", "http://test.example.com/api", null!, null!, null! });
+
+        var hash = Assert.IsType<Dictionary<string, object>>(result);
+        Assert.True(hash.ContainsKey("status"));
+        Assert.True(hash.ContainsKey("body"));
+        Assert.True(hash.ContainsKey("headers"));
+        Assert.True(hash.ContainsKey("ok"));
+        Assert.IsType<Dictionary<string, object>>(hash["headers"]);
+    }
+
+    [Fact]
+    public async Task HttpRequest_Response_Ok_True_For2xx()
+    {
+        SetupMock(HttpStatusCode.OK);
+        var ctx = new ScriptContext();
+        var result = await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "GET", "http://test.example.com/api", null!, null!, null! });
+        Assert.Equal(true, ((Dictionary<string, object>)result)["ok"]);
+    }
+
+    [Fact]
+    public async Task HttpRequest_Response_Ok_False_For4xx()
+    {
+        SetupMock(HttpStatusCode.NotFound);
+        var ctx = new ScriptContext();
+        var result = await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "GET", "http://test.example.com/missing", null!, null!, null! });
+        var hash = (Dictionary<string, object>)result;
+        Assert.Equal(404.0, hash["status"]);
+        Assert.Equal(false, hash["ok"]);
+    }
+
+    [Fact]
+    public async Task HttpRequest_Response_Headers()
+    {
+        SetupMock(HttpStatusCode.OK, "ok", new Dictionary<string, string> { ["X-Custom"] = "test-value" });
+        var ctx = new ScriptContext();
+        var result = await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "GET", "http://test.example.com/api", null!, null!, null! });
+        var hash = (Dictionary<string, object>)result;
+        var headers = (Dictionary<string, object>)hash["headers"];
+        Assert.Equal("test-value", headers["X-Custom"]);
+    }
+
+    #endregion
+
+    #region カスタムヘッダ
+
+    [Fact]
+    public async Task HttpRequest_CustomHeaders_Sent()
+    {
+        SetupMock();
+        var ctx = new ScriptContext();
+        var headers = new Dictionary<string, object>
+        {
+            ["Authorization"] = "Bearer token123",
+            ["Accept"] = "application/json"
+        };
+        await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "GET", "http://test.example.com/api", headers, null!, null! });
+
+        Assert.Contains("Bearer token123", _handler.LastRequest!.Headers.GetValues("Authorization"));
+        Assert.Contains("application/json", _handler.LastRequest.Headers.GetValues("Accept"));
+    }
+
+    [Fact]
+    public async Task HttpRequest_ContentType_SetOnBody()
+    {
+        SetupMock();
+        var ctx = new ScriptContext();
+        var headers = new Dictionary<string, object> { ["Content-Type"] = "application/json" };
+        await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "POST", "http://test.example.com/api", headers, "{}", null! });
+
+        Assert.NotNull(_handler.LastRequest!.Content);
+        Assert.Equal("application/json", _handler.LastRequest.Content!.Headers.ContentType!.MediaType);
+    }
+
+    #endregion
+
+    #region エラーハンドリング
+
+    [Fact]
+    public void HttpRequest_NullUrl_ThrowsException()
+    {
+        var ctx = new ScriptContext();
+        Assert.Throws<RuntimeException>(() =>
+            RuntimeHelpers.__httpRequest(ctx, new object[] { "GET", null!, null!, null!, null! }));
+    }
+
+    [Fact]
+    public async Task HttpRequest_NullHeaders_Accepted()
+    {
+        SetupMock(HttpStatusCode.OK, "ok");
+        var ctx = new ScriptContext();
+        var result = await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "GET", "http://test.example.com/api", null!, null!, null! });
+        var hash = (Dictionary<string, object>)result;
+        Assert.Equal(200.0, hash["status"]);
+    }
+
+    [Fact]
+    public async Task HttpRequest_NullBody_AcceptedForPost()
+    {
+        SetupMock();
+        var ctx = new ScriptContext();
+        await (Task<object>)RuntimeHelpers.__httpRequest(ctx,
+            new object[] { "POST", "http://test.example.com/api", null!, null!, null! });
+        Assert.Null(_handler.LastRequest!.Content);
+    }
+
+    #endregion
+
+    #region MockHttpMessageHandler
+
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _content;
+        private readonly Dictionary<string, string>? _responseHeaders;
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public MockHttpMessageHandler(HttpStatusCode statusCode = HttpStatusCode.OK,
+            string content = "", Dictionary<string, string>? responseHeaders = null)
+        {
+            _statusCode = statusCode;
+            _content = content;
+            _responseHeaders = responseHeaders;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_content)
+            };
+            if (_responseHeaders != null)
+            {
+                foreach (var h in _responseHeaders)
+                {
+                    response.Headers.TryAddWithoutValidation(h.Key, h.Value);
+                }
+            }
+            return Task.FromResult(response);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- `fetch(url, options?)` 汎用 HTTP リクエスト関数を追加
- `http.get/post/put/delete/patch` 便利メソッドオブジェクトを追加
- C# プリミティブ `__httpRequest`（HttpClient ベース、async/await 対応）
- Hash の GetMember でキーアクセスがプロトタイプメソッドより優先されるように修正

## Test plan
- [x] C# 単体テスト 15件（MockHttpMessageHandler でネットワーク不要）
- [x] E2E テスト 14件（ScriptEngine 経由、fetch/http 全メソッド + JSON 統合）
- [x] 既存テスト 1,271件が全パス（Hash 優先順位変更の回帰なし）
- [x] 合計 1,300テスト（1,288 + 12）

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)